### PR TITLE
Some tweaks for @astrodavid10

### DIFF
--- a/docs/api/toasty.builder.Builder.rst
+++ b/docs/api/toasty.builder.Builder.rst
@@ -25,6 +25,7 @@ Builder
       ~Builder.load_from_wwtl
       ~Builder.make_placeholder_thumbnail
       ~Builder.make_thumbnail_from_other
+      ~Builder.set_name
       ~Builder.tile_base_as_study
       ~Builder.toast_base
       ~Builder.write_index_rel_wtml
@@ -44,6 +45,7 @@ Builder
    .. automethod:: load_from_wwtl
    .. automethod:: make_placeholder_thumbnail
    .. automethod:: make_thumbnail_from_other
+   .. automethod:: set_name
    .. automethod:: tile_base_as_study
    .. automethod:: toast_base
    .. automethod:: write_index_rel_wtml

--- a/docs/cli/tile-allsky.rst
+++ b/docs/cli/tile-allsky.rst
@@ -16,6 +16,7 @@ Usage
       [standard image-loading options]
       [--placeholder-thumbnail]
       [--outdir DIR]
+      [--name NAME]
       [--projection TYPE]
       [--parallelism FACTOR]
       {IMAGE-PATH}
@@ -37,6 +38,9 @@ of the depth depends on your application.
 
 The ``--outdir DIR`` option specifies where the output data should be written.
 If unspecified, the data root will be the current directory.
+
+The ``--name NAME`` option specifies the descriptive name for the imagery to be
+embedded inside the output WTML file. It defaults to "Toasty".
 
 The ``--projection TYPE`` option specifies how the surface of the sphere is
 mapped on to the image. Allowed types are:

--- a/docs/cli/tile-study.rst
+++ b/docs/cli/tile-study.rst
@@ -16,6 +16,7 @@ Usage
       [standard image-loading options]
       [--placeholder-thumbnail]
       [--outdir DIR]
+      [--name NAME]
       IMAGE-PATH
 
 See the :ref:`cli-std-image-options` section for documentation on those options.
@@ -26,6 +27,9 @@ that needs to be tiled to be displayed usefully in AAS WorldWide Telescope.
 
 The ``--outdir DIR`` option specifies where the output data should be written.
 If unspecified, the data root will be the current directory.
+
+The ``--name NAME`` option specifies the descriptive name for the imagery to be
+embedded inside the output WTML file. It defaults to "Toasty".
 
 If the ``--placeholder-thumbnail`` argument is given, an all-black placeholder
 thumbnail will be created. Otherwise, the thumbnail will be created by

--- a/toasty/builder.py
+++ b/toasty/builder.py
@@ -200,7 +200,16 @@ class Builder(object):
 
         folder = Folder()
         folder.name = self.imgset.name
-        folder.children = [self.place]
+
+        # For all-sky/all-planet datasets, don't associate the imageset with a
+        # particular Place. Otherwise, loading up the imageset causes the view
+        # to zoom to a particular RA/Dec or lat/lon, likely 0,0. We might want
+        # to make this manually configurable but this heuristic should Do The
+        # Right Thing most times.
+        if self.imgset.projection == ProjectionType.TOAST:
+            folder.children = [self.imgset]
+        else:
+            folder.children = [self.place]
 
         with self.pio.open_metadata_for_write('index_rel.wtml') as f:
             write_xml_doc(folder.to_xml(), dest_stream=f, dest_wants_bytes=True)

--- a/toasty/builder.py
+++ b/toasty/builder.py
@@ -107,11 +107,15 @@ class Builder(object):
         return img
 
 
-    def toast_base(self, mode, sampler, depth, **kwargs):
+    def toast_base(self, mode, sampler, depth, is_planet=False, **kwargs):
         from .toast import sample_layer
         sample_layer(self.pio, mode, sampler, depth, **kwargs)
 
-        self.imgset.data_set_type = DataSetType.SKY
+        if is_planet:
+            self.imgset.data_set_type = DataSetType.PLANET
+        else:
+            self.imgset.data_set_type = DataSetType.SKY
+
         self.imgset.base_degrees_per_tile = 180
         self.imgset.file_type = '.png'
         self.imgset.projection = ProjectionType.TOAST

--- a/toasty/builder.py
+++ b/toasty/builder.py
@@ -180,6 +180,12 @@ class Builder(object):
         return self
 
 
+    def set_name(self, name):
+        self.imgset.name = name
+        self.place.name = name
+        return self
+
+
     def write_index_rel_wtml(self):
         from wwt_data_formats import write_xml_doc
         from wwt_data_formats.folder import Folder

--- a/toasty/cli.py
+++ b/toasty/cli.py
@@ -314,10 +314,16 @@ def tile_allsky_getparser(parser):
     ImageLoader.add_arguments(parser)
 
     parser.add_argument(
+        '--name',
+        metavar = 'NAME',
+        default = 'Toasty',
+        help = 'The image name to embed in the output WTML file (default: %(default)s)',
+    )
+    parser.add_argument(
         '--outdir',
         metavar = 'PATH',
         default = '.',
-        help = 'The root directory of the output tile pyramid',
+        help = 'The root directory of the output tile pyramid (default: %(default)s)',
     )
     parser.add_argument(
         '--placeholder-thumbnail',
@@ -335,7 +341,7 @@ def tile_allsky_getparser(parser):
         '--parallelism', '-j',
         metavar = 'COUNT',
         type = int,
-        help = 'The parallelization level (default: use all CPUs; specify `1` to force serial processing)',
+        help = 'The parallelization level (default: use all CPUs if OS supports; specify `1` to force serial processing)',
     )
     parser.add_argument(
         'imgpath',
@@ -385,6 +391,7 @@ def tile_allsky_impl(settings):
         parallel=settings.parallelism,
         cli_progress=True,
     )
+    builder.set_name(settings.name)
     builder.write_index_rel_wtml()
 
     print(f'Successfully tiled input "{settings.imgpath}" at level {builder.imgset.tile_levels}.')
@@ -399,6 +406,12 @@ def tile_study_getparser(parser):
     from .image import ImageLoader
     ImageLoader.add_arguments(parser)
 
+    parser.add_argument(
+        '--name',
+        metavar = 'NAME',
+        default = 'Toasty',
+        help = 'The image name to embed in the output WTML file (default: %(default)s)',
+    )
     parser.add_argument(
         '--placeholder-thumbnail',
         action = 'store_true',
@@ -434,6 +447,7 @@ def tile_study_impl(settings):
         builder.make_thumbnail_from_other(img)
 
     builder.tile_base_as_study(img, cli_progress=True)
+    builder.set_name(settings.name)
     builder.write_index_rel_wtml()
 
     print(f'Successfully tiled input "{settings.imgpath}" at level {builder.imgset.tile_levels}.')

--- a/toasty/cli.py
+++ b/toasty/cli.py
@@ -363,6 +363,7 @@ def tile_allsky_impl(settings):
 
     img = ImageLoader.create_from_args(settings).load_path(settings.imgpath)
     pio = PyramidIO(settings.outdir)
+    is_planet = False
 
     if settings.projection == 'plate-carree':
         from .samplers import plate_carree_sampler
@@ -373,6 +374,7 @@ def tile_allsky_impl(settings):
     elif settings.projection == 'plate-carree-planet':
         from .samplers import plate_carree_planet_sampler
         sampler = plate_carree_planet_sampler(img.asarray())
+        is_planet = True
     else:
         die('the image projection type {!r} is not recognized'.format(settings.projection))
 
@@ -388,6 +390,7 @@ def tile_allsky_impl(settings):
         img.mode,
         sampler,
         settings.depth,
+        is_planet=is_planet,
         parallel=settings.parallelism,
         cli_progress=True,
     )

--- a/toasty/tests/test_toast.py
+++ b/toasty/tests/test_toast.py
@@ -26,7 +26,7 @@ except ImportError:
     HAS_OPENEXR = False
 
 from . import test_path
-from .. import toast
+from .. import cli, toast
 from ..image import ImageLoader, ImageMode
 from ..pyramid import Pos, PyramidIO
 from ..samplers import plate_carree_sampler, healpix_fits_file_sampler
@@ -192,3 +192,31 @@ class TestSampleLayer(object):
         sampler = healpix_fits_file_sampler(test_path('earth_healpix_gal.fits'))
         sample_layer(self.pio, ImageMode.F32, sampler, 1)
         self.verify_level1(ImageMode.F32)
+
+
+class TestCliBasic(object):
+    """
+    Basic smoketests for the CLI. The more library-focused routines validate
+    detailed outputs.
+    """
+
+    def setup_method(self, method):
+        self.work_dir = mkdtemp()
+
+    def teardown_method(self, method):
+        from shutil import rmtree
+        rmtree(self.work_dir)
+
+    def work_path(self, *pieces):
+        return os.path.join(self.work_dir, *pieces)
+
+    def test_planet(self):
+        args = [
+            'tile-allsky',
+            '--name=Earth',
+            '--projection=plate-carree-planet',
+            '--outdir', self.work_path('basic_cli'),
+            test_path('Equirectangular_projection_SW-tweaked.jpg'),
+            '2',
+        ]
+        cli.entrypoint(args)


### PR DESCRIPTION
- Allow the name in the WTML to be customized
- Default to Planet dataset type when TOASTing in plate-carree-planet mode
- Omit the `<Place>` element wrapping all-sky `<ImageSet>`s