### PR TITLE
Specify UTF-8 encoding whenever working with text

### DIFF
--- a/toasty/pipeline.py
+++ b/toasty/pipeline.py
@@ -375,7 +375,7 @@ class AstroPixImageSource(ImageSource):
     def open_input(self, unique_id, cachedir):
         import json
 
-        with open(os.path.join(cachedir, 'astropix.json'), 'rt') as f:
+        with open(os.path.join(cachedir, 'astropix.json'), 'rt', encoding='utf8') as f:
             json_data = json.load(f)
 
         return AstroPixInputImage(unique_id, cachedir, json_data)
@@ -499,7 +499,7 @@ class AstroPixCandidateInput(CandidateInput):
 
         # Save the AstroPix metadata as well.
 
-        with open(os.path.join(cachedir, 'astropix.json'), 'wt') as f:
+        with open(os.path.join(cachedir, 'astropix.json'), 'wt', encoding='utf8') as f:
             json.dump(self._json, f)
 
 
@@ -843,7 +843,7 @@ class PipelineManager(object):
             with open(cfg_path, 'wb') as f:
                 self._pipeio.get_item('toasty-pipeline-config.yaml', dest=f)
 
-        with open(cfg_path, 'rt') as f:
+        with open(cfg_path, 'rt', encoding='utf8') as f:
             config = yaml.safe_load(f)
 
         if config is None:
@@ -926,7 +926,7 @@ class PipelineManager(object):
             # requires us to use some configuration data. The `place` that we
             # get out of the processing stage has relative URLs.
 
-            with open(self._path('out_todo', uniq_id, 'index_rel.wtml'), 'w') as f:
+            with open(self._path('out_todo', uniq_id, 'index_rel.wtml'), 'wt', encoding='utf8') as f:
                 write_xml_doc(folder.to_xml(), dest_stream=f)
 
             if pub_url_prefix:
@@ -936,7 +936,7 @@ class PipelineManager(object):
                 place.foreground_image_set.thumbnail_url = maybe_prefix_url(place.foreground_image_set.thumbnail_url, pfx)
                 place.thumbnail = maybe_prefix_url(place.thumbnail, pfx)
 
-                with open(self._path('out_todo', uniq_id, 'index.wtml'), 'w') as f:
+                with open(self._path('out_todo', uniq_id, 'index.wtml'), 'wt', encoding='utf8') as f:
                     write_xml_doc(folder.to_xml(), dest_stream=f)
 
             # All done here.

--- a/toasty/tests/test_pipeline.py
+++ b/toasty/tests/test_pipeline.py
@@ -25,7 +25,7 @@ class LocalTestAstroPixCandidateInput(pipeline.AstroPixCandidateInput):
 
         self._json['toasty_cached_image_name'] = 'image.' + ext
 
-        with open(os.path.join(cachedir, 'astropix.json'), 'wt') as f:
+        with open(os.path.join(cachedir, 'astropix.json'), 'wt', encoding='utf8') as f:
             json.dump(self._json, f)
 
 
@@ -65,7 +65,7 @@ class LocalTestAstroPixImageSource(pipeline.AstroPixImageSource):
     def open_input(self, unique_id, cachedir):
         import json
 
-        with open(os.path.join(cachedir, 'astropix.json'), 'rt') as f:
+        with open(os.path.join(cachedir, 'astropix.json'), 'rt', encoding='utf8') as f:
             json_data = json.load(f)
 
         return pipeline.AstroPixInputImage(unique_id, cachedir, json_data)

--- a/toasty/tests/test_study.py
+++ b/toasty/tests/test_study.py
@@ -83,7 +83,7 @@ class TestStudy(object):
             ]
             cli.entrypoint(args)
 
-        with open(self.work_path('index_rel.wtml')) as f:
+        with open(self.work_path('index_rel.wtml'), 'rt', encoding='utf8') as f:
             observed = etree.fromstring(f.read())
 
         assert_xml_elements_equal(observed, expected)


### PR DESCRIPTION
Some Windows Pythons default to encodings like CP1252, and we want to make sure that we don't accidentally use that.