### PR TITLE
Natively support OpenEXR HDR images

### DIFF
--- a/docs/api/toasty.cli.healpix_sample_data_tiles_getparser.rst
+++ b/docs/api/toasty.cli.healpix_sample_data_tiles_getparser.rst
@@ -1,6 +1,0 @@
-healpix_sample_data_tiles_getparser
-===================================
-
-.. currentmodule:: toasty.cli
-
-.. autofunction:: healpix_sample_data_tiles_getparser

--- a/docs/api/toasty.cli.healpix_sample_data_tiles_impl.rst
+++ b/docs/api/toasty.cli.healpix_sample_data_tiles_impl.rst
@@ -1,6 +1,0 @@
-healpix_sample_data_tiles_impl
-==============================
-
-.. currentmodule:: toasty.cli
-
-.. autofunction:: healpix_sample_data_tiles_impl

--- a/docs/api/toasty.cli.pipeline_fetch_inputs_getparser.rst
+++ b/docs/api/toasty.cli.pipeline_fetch_inputs_getparser.rst
@@ -1,6 +1,0 @@
-pipeline_fetch_inputs_getparser
-===============================
-
-.. currentmodule:: toasty.cli
-
-.. autofunction:: pipeline_fetch_inputs_getparser

--- a/docs/api/toasty.cli.pipeline_fetch_inputs_impl.rst
+++ b/docs/api/toasty.cli.pipeline_fetch_inputs_impl.rst
@@ -1,6 +1,0 @@
-pipeline_fetch_inputs_impl
-==========================
-
-.. currentmodule:: toasty.cli
-
-.. autofunction:: pipeline_fetch_inputs_impl

--- a/docs/api/toasty.cli.pipeline_getparser.rst
+++ b/docs/api/toasty.cli.pipeline_getparser.rst
@@ -1,0 +1,6 @@
+pipeline_getparser
+==================
+
+.. currentmodule:: toasty.cli
+
+.. autofunction:: pipeline_getparser

--- a/docs/api/toasty.cli.pipeline_impl.rst
+++ b/docs/api/toasty.cli.pipeline_impl.rst
@@ -1,0 +1,6 @@
+pipeline_impl
+=============
+
+.. currentmodule:: toasty.cli
+
+.. autofunction:: pipeline_impl

--- a/docs/api/toasty.cli.pipeline_process_todos_getparser.rst
+++ b/docs/api/toasty.cli.pipeline_process_todos_getparser.rst
@@ -1,6 +1,0 @@
-pipeline_process_todos_getparser
-================================
-
-.. currentmodule:: toasty.cli
-
-.. autofunction:: pipeline_process_todos_getparser

--- a/docs/api/toasty.cli.pipeline_process_todos_impl.rst
+++ b/docs/api/toasty.cli.pipeline_process_todos_impl.rst
@@ -1,6 +1,0 @@
-pipeline_process_todos_impl
-===========================
-
-.. currentmodule:: toasty.cli
-
-.. autofunction:: pipeline_process_todos_impl

--- a/docs/api/toasty.cli.pipeline_publish_todos_getparser.rst
+++ b/docs/api/toasty.cli.pipeline_publish_todos_getparser.rst
@@ -1,6 +1,0 @@
-pipeline_publish_todos_getparser
-================================
-
-.. currentmodule:: toasty.cli
-
-.. autofunction:: pipeline_publish_todos_getparser

--- a/docs/api/toasty.cli.pipeline_publish_todos_impl.rst
+++ b/docs/api/toasty.cli.pipeline_publish_todos_impl.rst
@@ -1,6 +1,0 @@
-pipeline_publish_todos_impl
-===========================
-
-.. currentmodule:: toasty.cli
-
-.. autofunction:: pipeline_publish_todos_impl

--- a/docs/api/toasty.cli.pipeline_reindex_getparser.rst
+++ b/docs/api/toasty.cli.pipeline_reindex_getparser.rst
@@ -1,6 +1,0 @@
-pipeline_reindex_getparser
-==========================
-
-.. currentmodule:: toasty.cli
-
-.. autofunction:: pipeline_reindex_getparser

--- a/docs/api/toasty.cli.pipeline_reindex_impl.rst
+++ b/docs/api/toasty.cli.pipeline_reindex_impl.rst
@@ -1,6 +1,0 @@
-pipeline_reindex_impl
-=====================
-
-.. currentmodule:: toasty.cli
-
-.. autofunction:: pipeline_reindex_impl

--- a/docs/api/toasty.cli.tile_healpix_getparser.rst
+++ b/docs/api/toasty.cli.tile_healpix_getparser.rst
@@ -1,0 +1,6 @@
+tile_healpix_getparser
+======================
+
+.. currentmodule:: toasty.cli
+
+.. autofunction:: tile_healpix_getparser

--- a/docs/api/toasty.cli.tile_healpix_impl.rst
+++ b/docs/api/toasty.cli.tile_healpix_impl.rst
@@ -1,0 +1,6 @@
+tile_healpix_impl
+=================
+
+.. currentmodule:: toasty.cli
+
+.. autofunction:: tile_healpix_impl

--- a/docs/api/toasty.cli.transform_getparser.rst
+++ b/docs/api/toasty.cli.transform_getparser.rst
@@ -1,0 +1,6 @@
+transform_getparser
+===================
+
+.. currentmodule:: toasty.cli
+
+.. autofunction:: transform_getparser

--- a/docs/api/toasty.cli.transform_impl.rst
+++ b/docs/api/toasty.cli.transform_impl.rst
@@ -1,0 +1,6 @@
+transform_impl
+==============
+
+.. currentmodule:: toasty.cli
+
+.. autofunction:: transform_impl

--- a/docs/api/toasty.image.ImageMode.rst
+++ b/docs/api/toasty.image.ImageMode.rst
@@ -10,6 +10,7 @@ ImageMode
 
    .. autosummary::
 
+      ~ImageMode.F16x3
       ~ImageMode.F32
       ~ImageMode.RGB
       ~ImageMode.RGBA
@@ -24,6 +25,7 @@ ImageMode
 
    .. rubric:: Attributes Documentation
 
+   .. autoattribute:: F16x3
    .. autoattribute:: F32
    .. autoattribute:: RGB
    .. autoattribute:: RGBA

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -10,3 +10,4 @@ CLI Reference
    cli/tile-allsky
    cli/tile-study
    cli/tile-wwtl
+   cli/transform-fx3-to-rgb

--- a/docs/cli/cascade.rst
+++ b/docs/cli/cascade.rst
@@ -12,13 +12,26 @@ Usage
 
 .. code-block:: shell
 
-   toasty cascade [--parallelism FACTOR] {--start DEPTH} PYRAMID-DIR
+   toasty cascade
+      [--parallelism FACTOR]
+      [--type TYPE]
+      {--start DEPTH}
+      PYRAMID-DIR
 
 The ``PYRAMID-DIR`` argument gives the location of a directory containing tile
 pyramid data files. The ``--start DEPTH`` argument gives the depth at which
 tiles *already exist*. For instance, with ``--start 5``, the pyramid should
 contain level-5 tiles, and the cascade will fill in tiles between levels 4 and
 0, inclusive.
+
+Each tile pyramid directory may contain multiple ”types” of data. The ``--type``
+argument specifies which one the cascade operation shoul apply to. Valid choices
+are ``rgba`` (the default), ``f16x3``, and ``f32``. The ``f32`` option applies
+to single-plan 32-bit floating-point data. The ``f16x3`` option applies to
+three-plane, 16-bit (“half precision”) floating point data such as may be stored
+in an `OpenEXR`_ file.
+
+.. _OpenEXR: https://www.openexr.com/
 
 The ``--parallelism FACTOR`` argument specifies the level of parallism to use.
 On operating systems that support parallel processing, the default is to use

--- a/docs/cli/transform-fx3-to-rgb.rst
+++ b/docs/cli/transform-fx3-to-rgb.rst
@@ -22,7 +22,9 @@ See the :ref:`cli-std-image-options` section for documentation on those options.
 
 The ``PYRAMID-DIR`` argument gives the name of a tile pyramid. It should contain
 Numpy data files in one of the supported Toasty “Fx3” formats. One potential
-source of such data is tiling an OpenEXR file.
+source of such data is tiling an `OpenEXR`_ file.
+
+.. _OpenEXR: https://www.openexr.com/
 
 The ``--clip NUMBER`` argument specifies the point at which the floating-point
 values will be clipped. By default, the input floating-point data are expected

--- a/docs/cli/transform-fx3-to-rgb.rst
+++ b/docs/cli/transform-fx3-to-rgb.rst
@@ -1,0 +1,44 @@
+.. _cli-transform-fx3-to-rgb:
+
+===============================
+``toasty transform fx3-to-rgb``
+===============================
+
+The ``transform fx3-to-rgb`` command transform a pyramid in an “Fx3” format —
+three planes of floating-point data — and converts them to RGB(A) image files.
+
+Usage
+=====
+
+.. code-block:: shell
+
+   toasty transform fx3-to-rgb
+      [--parallelism FACTOR]
+      [--start DEPTH]
+      [--clip NUMBER]
+      {PYRAMID-DIR}
+
+See the :ref:`cli-std-image-options` section for documentation on those options.
+
+The ``PYRAMID-DIR`` argument gives the name of a tile pyramid. It should contain
+Numpy data files in one of the supported Toasty “Fx3” formats. One potential
+source of such data is tiling an OpenEXR file.
+
+The ``--clip NUMBER`` argument specifies the point at which the floating-point
+values will be clipped. By default, the input floating-point data are expected
+to range between 0 and 1, which will be mapped to the range 0–255 in the
+standard 8-bit RGB color scheme. If, for example, you specify ``--clip=0.1``,
+then floating-point values of 0.1 will be mapped to 255 (i.e. full brightness).
+Values greater than this cutoff will be clipped and appear equally bright in the
+output RGB images.
+
+The ``--parallelism FACTOR`` argument specifies the level of parallism to use.
+On operating systems that support parallel processing, the default is to use
+all CPUs. To disable parallel processing, explicitly specify a factor of 1.
+
+Notes
+=====
+
+After the clip is applied, the floating-point data have a square-root transform
+applied before being mapped to RGB values. This could/should be made
+configurable, but this hasn't yet been done.

--- a/toasty/cli.py
+++ b/toasty/cli.py
@@ -156,7 +156,7 @@ def multi_tan_make_data_tiles_impl(settings):
     # TODO: this should populate and emit a stub index_rel.wtml file.
 
 
-# "pipeline_fetch_inputs" subcommand
+# "pipeline" subcommands
 
 def _pipeline_add_io_args(parser):
     parser.add_argument(
@@ -209,7 +209,10 @@ def _pipeline_io_from_settings(settings):
     die('An I/O backend must be specified with the arguments --local or --azure-*')
 
 
-def pipeline_fetch_inputs_getparser(parser):
+def pipeline_getparser(parser):
+    subparsers = parser.add_subparsers(dest='pipeline_command')
+
+    parser = subparsers.add_parser('fetch-inputs')
     _pipeline_add_io_args(parser)
     parser.add_argument(
         'workdir',
@@ -218,17 +221,7 @@ def pipeline_fetch_inputs_getparser(parser):
         help = 'The local working directory',
     )
 
-def pipeline_fetch_inputs_impl(settings):
-    from .pipeline import PipelineManager
-
-    pipeio = _pipeline_io_from_settings(settings)
-    mgr = PipelineManager(pipeio, settings.workdir)
-    mgr.fetch_inputs()
-
-
-# "pipeline_process_todos" subcommand
-
-def pipeline_process_todos_getparser(parser):
+    parser = subparsers.add_parser('process-todos')
     _pipeline_add_io_args(parser)
     parser.add_argument(
         'workdir',
@@ -237,17 +230,7 @@ def pipeline_process_todos_getparser(parser):
         help = 'The local working directory',
     )
 
-def pipeline_process_todos_impl(settings):
-    from .pipeline import PipelineManager
-
-    pipeio = _pipeline_io_from_settings(settings)
-    mgr = PipelineManager(pipeio, settings.workdir)
-    mgr.process_todos()
-
-
-# "pipeline_publish_todos" subcommand
-
-def pipeline_publish_todos_getparser(parser):
+    parser = subparsers.add_parser('publish-todos')
     _pipeline_add_io_args(parser)
     parser.add_argument(
         'workdir',
@@ -256,17 +239,7 @@ def pipeline_publish_todos_getparser(parser):
         help = 'The local working directory',
     )
 
-def pipeline_publish_todos_impl(settings):
-    from .pipeline import PipelineManager
-
-    pipeio = _pipeline_io_from_settings(settings)
-    mgr = PipelineManager(pipeio, settings.workdir)
-    mgr.publish_todos()
-
-
-# "pipeline_reindex" subcommand
-
-def pipeline_reindex_getparser(parser):
+    parser = subparsers.add_parser('reindex')
     _pipeline_add_io_args(parser)
     parser.add_argument(
         'workdir',
@@ -275,12 +248,27 @@ def pipeline_reindex_getparser(parser):
         help = 'The local working directory',
     )
 
-def pipeline_reindex_impl(settings):
+
+def pipeline_impl(settings):
     from .pipeline import PipelineManager
+
+    if settings.pipeline_command is None:
+        print('Run the "pipeline" command with `--help` for help on its subcommands')
+        return
 
     pipeio = _pipeline_io_from_settings(settings)
     mgr = PipelineManager(pipeio, settings.workdir)
-    mgr.reindex()
+
+    if settings.pipeline_command == 'fetch-inputs':
+        mgr.fetch_inputs()
+    elif settings.pipeline_command == 'process-todos':
+        mgr.process_todos()
+    elif settings.pipeline_command == 'publish-todos':
+        mgr.publish_todos()
+    elif settings.pipeline_command == 'reindex':
+        mgr.reindex()
+    else:
+        die('unrecognized "pipeline" subcommand ' + settings.pipeline_command)
 
 
 # "tile_allsky" subcommand

--- a/toasty/cli.py
+++ b/toasty/cli.py
@@ -32,6 +32,13 @@ def cascade_getparser(parser):
         help = 'The parallelization level (default: use all CPUs; specify `1` to force serial processing)',
     )
     parser.add_argument(
+        '--type', '-t',
+        metavar = 'TYPE',
+        default = 'rgba',
+        choices = ['rgba', 'f16x3', 'f32'],
+        help = 'The kind of data file to cascade',
+    )
+    parser.add_argument(
         '--start',
         metavar = 'DEPTH',
         type = int,
@@ -55,9 +62,18 @@ def cascade_impl(settings):
     if start is None:
         die('currently, you must specify the start layer with the --start option')
 
+    if settings.type == 'rgba':
+        mode = ImageMode.RGBA
+    elif settings.type == 'f16x3':
+        mode = ImageMode.F16x3
+    elif settings.type == 'f32':
+        mode = ImageMode.F32
+    else:
+        die(f'unexpected "type" argument {settings.type}')
+
     cascade_images(
         pio,
-        ImageMode.RGBA,
+        mode,
         start,
         averaging_merger,
         parallel=settings.parallelism,

--- a/toasty/cli.py
+++ b/toasty/cli.py
@@ -47,7 +47,7 @@ def cascade_getparser(parser):
     parser.add_argument(
         'pyramid_dir',
         metavar = 'DIR',
-        help = 'The directory containg the tile pyramid to cascade',
+        help = 'The directory containing the tile pyramid to cascade',
     )
 
 
@@ -509,6 +509,58 @@ def tile_wwtl_impl(settings):
     print('To create parent tiles, consider running:')
     print()
     print(f'   toasty cascade --start {builder.imgset.tile_levels} {settings.outdir}')
+
+
+# "transform" subcommand
+
+def transform_getparser(parser):
+    subparsers = parser.add_subparsers(dest='transform_command')
+
+    parser = subparsers.add_parser('fx3-to-rgb')
+    parser.add_argument(
+        '--parallelism', '-j',
+        metavar = 'COUNT',
+        type = int,
+        help = 'The parallelization level (default: use all CPUs; specify `1` to force serial processing)',
+    )
+    parser.add_argument(
+        '--start',
+        metavar = 'DEPTH',
+        type = int,
+        help = 'The depth of the pyramid layer to start the cascade',
+    )
+    parser.add_argument(
+        '--clip', '-c',
+        metavar = 'NUMBER',
+        type = float,
+        default = 1.0,
+        help = 'The level at which to start flipping the floating-point data',
+    )
+    parser.add_argument(
+        'pyramid_dir',
+        metavar = 'DIR',
+        help = 'The directory containing the tile pyramid to cascade',
+    )
+
+
+def transform_impl(settings):
+    from .pyramid import PyramidIO
+
+    if settings.transform_command is None:
+        print('Run the "transform" command with `--help` for help on its subcommands')
+        return
+
+    if settings.transform_command == 'fx3-to-rgb':
+        from .transform import f16x3_to_rgb
+        pio = PyramidIO(settings.pyramid_dir)
+        f16x3_to_rgb(
+            pio, settings.start,
+            clip = settings.clip,
+            parallel = settings.parallelism,
+            cli_progress = True,
+        )
+    else:
+        die('unrecognized "transform" subcommand ' + settings.transform_command)
 
 
 # The CLI driver:

--- a/toasty/cli.py
+++ b/toasty/cli.py
@@ -81,46 +81,6 @@ def cascade_impl(settings):
     )
 
 
-# "healpix_sample_data_tiles" subcommand
-
-def healpix_sample_data_tiles_getparser(parser):
-    parser.add_argument(
-        '--outdir',
-        metavar = 'PATH',
-        default = '.',
-        help = 'The root directory of the output tile pyramid',
-    )
-    parser.add_argument(
-        'fitspath',
-        metavar = 'PATH',
-        help = 'The HEALPix FITS file to be tiled',
-    )
-    parser.add_argument(
-        'depth',
-        metavar = 'DEPTH',
-        type = int,
-        help = 'The depth of the TOAST layer to sample',
-    )
-
-
-def healpix_sample_data_tiles_impl(settings):
-    from .builder import Builder
-    from .image import ImageMode
-    from .pyramid import PyramidIO
-    from .samplers import healpix_fits_file_sampler
-
-    pio = PyramidIO(settings.outdir)
-    sampler = healpix_fits_file_sampler(settings.fitspath)
-    builder = Builder(pio)
-    builder.toast_base(ImageMode.F32, sampler, settings.depth)
-    builder.write_index_rel_wtml()
-
-    print(f'Successfully tiled input "{settings.fitspath}" at level {builder.imgset.tile_levels}.')
-    print('To create parent tiles, consider running:')
-    print()
-    print(f'   toasty cascade --start {builder.imgset.tile_levels} {settings.outdir}')
-
-
 # "make_thumbnail" subcommand
 
 def make_thumbnail_getparser(parser):
@@ -414,6 +374,46 @@ def tile_allsky_impl(settings):
     builder.write_index_rel_wtml()
 
     print(f'Successfully tiled input "{settings.imgpath}" at level {builder.imgset.tile_levels}.')
+    print('To create parent tiles, consider running:')
+    print()
+    print(f'   toasty cascade --start {builder.imgset.tile_levels} {settings.outdir}')
+
+
+# "tile_healpix" subcommand
+
+def tile_healpix_getparser(parser):
+    parser.add_argument(
+        '--outdir',
+        metavar = 'PATH',
+        default = '.',
+        help = 'The root directory of the output tile pyramid',
+    )
+    parser.add_argument(
+        'fitspath',
+        metavar = 'PATH',
+        help = 'The HEALPix FITS file to be tiled',
+    )
+    parser.add_argument(
+        'depth',
+        metavar = 'DEPTH',
+        type = int,
+        help = 'The depth of the TOAST layer to sample',
+    )
+
+
+def tile_healpix_impl(settings):
+    from .builder import Builder
+    from .image import ImageMode
+    from .pyramid import PyramidIO
+    from .samplers import healpix_fits_file_sampler
+
+    pio = PyramidIO(settings.outdir)
+    sampler = healpix_fits_file_sampler(settings.fitspath)
+    builder = Builder(pio)
+    builder.toast_base(ImageMode.F32, sampler, settings.depth)
+    builder.write_index_rel_wtml()
+
+    print(f'Successfully tiled input "{settings.fitspath}" at level {builder.imgset.tile_levels}.')
     print('To create parent tiles, consider running:')
     print()
     print(f'   toasty cascade --start {builder.imgset.tile_levels} {settings.outdir}')

--- a/toasty/openexr.py
+++ b/toasty/openexr.py
@@ -20,40 +20,6 @@ import numpy as np
 import sys
 
 
-def _util_load_openexr_float(path):
-    """
-    A diagnostic/utility function to load OpenEXR as float data.
-
-    """
-    import OpenEXR
-    import Imath
-
-    EXR_TO_NUMPY = {
-        Imath.PixelType.FLOAT: np.float32,
-        Imath.PixelType.HALF: np.float16,
-    }
-
-    exr = OpenEXR.InputFile(path)
-    header = exr.header()
-    dw = header['dataWindow']
-    width = dw.max.x - dw.min.x + 1
-    height = dw.max.y - dw.min.y + 1
-
-    img = None
-
-    for idx, chan in enumerate('RGB'):
-        ctype = header['channels'][chan].type
-        cbytes = exr.channel(chan)
-        dtype = EXR_TO_NUMPY[ctype.v]
-
-        if img is None:
-            img = np.empty((height, width, 3), dtype=dtype)
-
-        img[...,idx] = np.frombuffer(cbytes, dtype=dtype).reshape((height, width))
-
-    return img
-
-
 def load_openexr(path):
     """
     Load an OpenEXR file
@@ -66,7 +32,7 @@ def load_openexr(path):
     Returns
     -------
     An image-like Numpy array with shape ``(height, width, planes)``
-    and a dtype of uint8.
+    and a dtype of float16 or float32. (Toasty only fully supports float16.)
 
     """
     try:
@@ -97,37 +63,18 @@ def load_openexr(path):
         print('warning: ignoring whiteLuminance in OpenEXR file; colors will be distorted',
               file=sys.stderr)
 
-    img = np.empty((height, width, 3), dtype=np.uint8)
+    img = None
 
     try:
         for idx, chan in enumerate('RGB'):
             ctype = header['channels'][chan].type
             cbytes = exr.channel(chan)
-            carr = np.frombuffer(cbytes, dtype=EXR_TO_NUMPY[ctype.v]).reshape((height, width))
+            dtype = EXR_TO_NUMPY[ctype.v]
 
-            # XXX: manually implemented sRGB conversion is not awesome, and also
-            # ideally this wouldn't be done here. Equations from
-            # https://discourse.techart.online/t/converting-linear-exr-to-srgb-jpeg-with-python/2267/3
+            if img is None:
+                img = np.empty((height, width, 3), dtype=dtype)
 
-            # Need a read-write buffer:
-            work = carr.copy()
-
-            # Small-value branch of sGRB. Assume that there aren't many of
-            # these, and avoid modifying non-small values.
-            mask = (carr <= 0.0031308)
-            del carr
-            work[mask] *= 12.92 * 255
-            np.copyto(img[...,idx], work, where=mask, casting='unsafe')
-
-            # Main branch. Replace small values with something that won't
-            # give math errors.
-            work[mask] = 0.0032
-            np.power(work, 1 / 2.4, out=work)
-            np.multiply(work, 1.055, out=work)
-            np.subtract(work, 0.055, out=work)
-            np.multiply(work, 255, out=work)
-            np.logical_not(mask, out=mask)
-            np.copyto(img[...,idx], work, where=mask, casting='unsafe')
+            img[...,idx] = np.frombuffer(cbytes, dtype=dtype).reshape((height, width))
     except Exception as e:
         raise Exception('cannot load OpenEXR file: unexpected file structure') from e
 

--- a/toasty/tests/test_pipeline.py
+++ b/toasty/tests/test_pipeline.py
@@ -90,28 +90,28 @@ class TestPipeline(object):
 
     def test_workflow(self):
         args = [
-            'pipeline-fetch-inputs',
+            'pipeline', 'fetch-inputs',
             '--local', self.work_path('repo'),
             self.work_path('work'),
         ]
         cli.entrypoint(args)
 
         args = [
-            'pipeline-process-todos',
+            'pipeline', 'process-todos',
             '--local', self.work_path('repo'),
             self.work_path('work'),
         ]
         cli.entrypoint(args)
 
         args = [
-            'pipeline-publish-todos',
+            'pipeline', 'publish-todos',
             '--local', self.work_path('repo'),
             self.work_path('work'),
         ]
         cli.entrypoint(args)
 
         args = [
-            'pipeline-reindex',
+            'pipeline', 'reindex',
             '--local', self.work_path('repo'),
             self.work_path('work'),
         ]
@@ -120,14 +120,14 @@ class TestPipeline(object):
     def test_args(self):
         with pytest.raises(SystemExit):
             args = [
-                'pipeline-fetch-inputs',
+                'pipeline', 'fetch-inputs',
                 self.work_path('work'),
             ]
             cli.entrypoint(args)
 
         with pytest.raises(SystemExit):
             args = [
-                'pipeline-fetch-inputs',
+                'pipeline', 'fetch-inputs',
                 '--azure-conn-env', 'NOTAVARIABLE',
                 self.work_path('work'),
             ]
@@ -137,7 +137,7 @@ class TestPipeline(object):
 
         with pytest.raises(SystemExit):
             args = [
-                'pipeline-fetch-inputs',
+                'pipeline', 'fetch-inputs',
                 '--azure-conn-env', 'FAKECONNSTRING',
                 self.work_path('work'),
             ]

--- a/toasty/tests/test_samplers.py
+++ b/toasty/tests/test_samplers.py
@@ -39,7 +39,7 @@ class TestSamplers(object):
 
         """
         args = [
-            'healpix-sample-data-tiles',
+            'tile-healpix',
             '--outdir', self.work_path('basic_cli'),
             test_path('earth_healpix_equ.fits'),
             '1',

--- a/toasty/tests/test_toast.py
+++ b/toasty/tests/test_toast.py
@@ -178,8 +178,9 @@ class TestSampleLayer(object):
     def test_earth_plate_caree_exr(self):
         img = ImageLoader().load_path(test_path('Equirectangular_projection_SW-tweaked.exr'))
         sampler = plate_carree_sampler(img.asarray())
-        sample_layer(self.pio, ImageMode.RGB, sampler, 1)
-        self.verify_level1(ImageMode.RGB)
+        sample_layer(self.pio, ImageMode.F16x3, sampler, 1)
+        # XXX just smoketest until we get F16-to-RGB conversion going
+        #self.verify_level1(ImageMode.RGB)
 
     @pytest.mark.skipif('not HAS_ASTRO')
     def test_healpix_equ(self):

--- a/toasty/tests/test_toast.py
+++ b/toasty/tests/test_toast.py
@@ -31,6 +31,7 @@ from ..image import ImageLoader, ImageMode
 from ..pyramid import Pos, PyramidIO
 from ..samplers import plate_carree_sampler, healpix_fits_file_sampler
 from ..toast import sample_layer
+from ..transform import f16x3_to_rgb
 
 
 def test_mid():
@@ -179,8 +180,8 @@ class TestSampleLayer(object):
         img = ImageLoader().load_path(test_path('Equirectangular_projection_SW-tweaked.exr'))
         sampler = plate_carree_sampler(img.asarray())
         sample_layer(self.pio, ImageMode.F16x3, sampler, 1)
-        # XXX just smoketest until we get F16-to-RGB conversion going
-        #self.verify_level1(ImageMode.RGB)
+        f16x3_to_rgb(self.pio, 1, parallel=1)
+        self.verify_level1(ImageMode.RGB)
 
     @pytest.mark.skipif('not HAS_ASTRO')
     def test_healpix_equ(self):

--- a/toasty/transform.py
+++ b/toasty/transform.py
@@ -1,0 +1,124 @@
+# -*- mode: python; coding: utf-8 -*-
+# Copyright 2020 the AAS WorldWide Telescope project
+# Licensed under the MIT License.
+
+"""
+Within-tile data transformations. Mainly, transforming floating-point data to
+RGB.
+"""
+
+__all__ = '''
+f16x3_to_rgb
+'''.split()
+
+from astropy import visualization as viz
+import numpy as np
+from tqdm import tqdm
+
+from .image import ImageMode, Image
+from .pyramid import depth2tiles, generate_pos
+
+
+def f16x3_to_rgb(pio, start_depth, clip=1, parallel=None, cli_progress=False):
+    transform = viz.SqrtStretch() + viz.ManualInterval(0, clip)
+    _float_to_rgb(pio, start_depth, ImageMode.F16x3, transform, parallel=parallel, cli_progress=cli_progress)
+
+
+def _float_to_rgb(pio, depth, read_mode, transform, parallel=None, cli_progress=False):
+    from .par_util import resolve_parallelism
+    parallel = resolve_parallelism(parallel)
+
+    if parallel > 1:
+        _float_to_rgb_parallel(pio, depth, read_mode, transform, cli_progress, parallel)
+    else:
+        _float_to_rgb_serial(pio, depth, read_mode, transform, cli_progress)
+
+
+def _float_to_rgb_serial(pio, depth, read_mode, transform, cli_progress):
+    buf = np.empty((256, 256, 4), dtype=np.uint8)
+
+    with tqdm(total=depth2tiles(depth), disable=not cli_progress) as progress:
+        for pos in generate_pos(depth):
+            _float_to_rgb_do_one(buf, pos, pio, read_mode, transform)
+            progress.update(1)
+
+    if cli_progress:
+        print()
+
+
+def _float_to_rgb_parallel(pio, depth, read_mode, transform, cli_progress, parallel):
+    import multiprocessing as mp
+
+    # Start up the workers
+
+    queue = mp.Queue(maxsize = 16 * parallel)
+    workers = []
+
+    for _ in range(parallel):
+        w = mp.Process(target=_float_to_rgb_mp_worker, args=(queue, pio, read_mode, transform))
+        w.daemon = True
+        w.start()
+        workers.append(w)
+
+    # Send out them tiles
+
+    with tqdm(total=depth2tiles(depth), disable=not cli_progress) as progress:
+        for pos in generate_pos(depth):
+              queue.put(pos)
+              progress.update(1)
+
+        queue.close()
+
+        for w in workers:
+            w.join()
+
+    if cli_progress:
+        print()
+
+
+def _float_to_rgb_mp_worker(queue, pio, read_mode, transform):
+    """
+    Do the colormapping.
+    """
+    from queue import Empty
+
+    buf = np.empty((256, 256, 4), dtype=np.uint8)
+
+    while True:
+        try:
+            pos = queue.get(True, timeout=1)
+        except (OSError, ValueError, Empty):
+            # OSError or ValueError => queue closed. This signal seems not to
+            # cross multiprocess lines, though.
+            break
+
+        _float_to_rgb_do_one(buf, pos, pio, read_mode, transform)
+
+
+def _float_to_rgb_do_one(buf, pos, pio, read_mode, transform):
+    """
+    Do one float-to-RGB job. This problem is embarassingly parallel so we can
+    share code between the serial and parallel implementations.
+    """
+    img = pio.read_image(pos, read_mode)
+    if img is None:
+        return
+
+    mapped = transform(img.asarray())
+
+    if mapped.ndim == 2:
+        # TODO: allow real colormaps
+        valid = np.isfinite(mapped)
+        mapped[~valid] = 0
+        mapped = np.clip(mapped * 255, 0, 255).astype(np.uint8)
+        buf[...,:3] = mapped.reshape((256, 256, 1))
+        buf[...,3] = 255 * valid
+    else:
+        valid = np.all(np.isfinite(mapped), axis=2)
+        mapped[~valid] = 0
+        mapped = np.clip(mapped * 255, 0, 255).astype(np.uint8)
+        buf[...,:3] = mapped
+        buf[...,3] = 255 * valid
+
+    rgb = Image.from_array(ImageMode.RGBA, buf)
+    pio.write_image(pos, rgb)


### PR DESCRIPTION
Now we tile them as an "F16x3" format that is then convertible to RGB in a separate step. This means that as we downsample a large tiled image, we don't lose all of the flux due to dynamic-range compression in the 8-bit color.