### PR TITLE
Add support for tiling FITS studies

### DIFF
--- a/docs/api/toasty.image.Image.rst
+++ b/docs/api/toasty.image.Image.rst
@@ -27,7 +27,7 @@ Image
       ~Image.from_array
       ~Image.from_pil
       ~Image.make_thumbnail_bitmap
-      ~Image.save_default
+      ~Image.save
       ~Image.update_into_maskable_buffer
 
    .. rubric:: Attributes Documentation
@@ -47,5 +47,5 @@ Image
    .. automethod:: from_array
    .. automethod:: from_pil
    .. automethod:: make_thumbnail_bitmap
-   .. automethod:: save_default
+   .. automethod:: save
    .. automethod:: update_into_maskable_buffer

--- a/docs/api/toasty.image.ImageLoader.rst
+++ b/docs/api/toasty.image.ImageLoader.rst
@@ -13,7 +13,6 @@ ImageLoader
       ~ImageLoader.black_to_transparent
       ~ImageLoader.colorspace_processing
       ~ImageLoader.crop
-      ~ImageLoader.desired_mode
       ~ImageLoader.psd_single_layer
 
    .. rubric:: Methods Summary
@@ -31,7 +30,6 @@ ImageLoader
    .. autoattribute:: black_to_transparent
    .. autoattribute:: colorspace_processing
    .. autoattribute:: crop
-   .. autoattribute:: desired_mode
    .. autoattribute:: psd_single_layer
 
    .. rubric:: Methods Documentation

--- a/docs/api/toasty.image.ImageMode.rst
+++ b/docs/api/toasty.image.ImageMode.rst
@@ -19,7 +19,6 @@ ImageMode
 
    .. autosummary::
 
-      ~ImageMode.get_default_save_extension
       ~ImageMode.make_maskable_buffer
       ~ImageMode.try_as_pil
 
@@ -32,6 +31,5 @@ ImageMode
 
    .. rubric:: Methods Documentation
 
-   .. automethod:: get_default_save_extension
    .. automethod:: make_maskable_buffer
    .. automethod:: try_as_pil

--- a/docs/cli/cascade.rst
+++ b/docs/cli/cascade.rst
@@ -14,7 +14,7 @@ Usage
 
    toasty cascade
       [--parallelism FACTOR]
-      [--type TYPE]
+      [--format FORMAT]
       {--start DEPTH}
       PYRAMID-DIR
 
@@ -24,12 +24,10 @@ tiles *already exist*. For instance, with ``--start 5``, the pyramid should
 contain level-5 tiles, and the cascade will fill in tiles between levels 4 and
 0, inclusive.
 
-Each tile pyramid directory may contain multiple ”types” of data. The ``--type``
-argument specifies which one the cascade operation shoul apply to. Valid choices
-are ``rgba`` (the default), ``f16x3``, and ``f32``. The ``f32`` option applies
-to single-plan 32-bit floating-point data. The ``f16x3`` option applies to
-three-plane, 16-bit (“half precision”) floating point data such as may be stored
-in an `OpenEXR`_ file.
+Each tile pyramid directory may contain multiple data formats (e.g. PNG, FITS). The ``--type``
+argument specifies which one the cascade operation should apply to. Valid choices
+are ``png``, ``jpg``, ``npy``, and ``fits``. The default is to try and determine the
+format automatically.
 
 .. _OpenEXR: https://www.openexr.com/
 

--- a/toasty/builder.py
+++ b/toasty/builder.py
@@ -147,7 +147,7 @@ class Builder(object):
         from .image import Image, ImageMode
 
         arr = np.zeros((45, 96, 3), dtype=np.uint8)
-        img = Image.from_array(ImageMode.RGB, arr)
+        img = Image.from_array(arr)
 
         with self.pio.open_metadata_for_write('thumb.jpg') as f:
             img.aspil().save(f, format='JPEG')

--- a/toasty/builder.py
+++ b/toasty/builder.py
@@ -107,9 +107,9 @@ class Builder(object):
         return img
 
 
-    def toast_base(self, mode, sampler, depth, is_planet=False, **kwargs):
+    def toast_base(self, sampler, depth, is_planet=False, **kwargs):
         from .toast import sample_layer
-        sample_layer(self.pio, mode, sampler, depth, **kwargs)
+        sample_layer(self.pio, sampler, depth, **kwargs)
 
         if is_planet:
             self.imgset.data_set_type = DataSetType.PLANET
@@ -127,9 +127,8 @@ class Builder(object):
 
 
     def cascade(self, **kwargs):
-        from .image import ImageMode
         from .merge import averaging_merger, cascade_images
-        cascade_images(self.pio, ImageMode.RGBA, self.imgset.tile_levels, averaging_merger, **kwargs)
+        cascade_images(self.pio, self.imgset.tile_levels, averaging_merger, **kwargs)
         return self
 
 
@@ -144,7 +143,7 @@ class Builder(object):
 
     def make_placeholder_thumbnail(self):
         import numpy as np
-        from .image import Image, ImageMode
+        from .image import Image
 
         arr = np.zeros((45, 96, 3), dtype=np.uint8)
         img = Image.from_array(arr)

--- a/toasty/cli.py
+++ b/toasty/cli.py
@@ -32,11 +32,11 @@ def cascade_getparser(parser):
         help = 'The parallelization level (default: use all CPUs; specify `1` to force serial processing)',
     )
     parser.add_argument(
-        '--type', '-t',
-        metavar = 'TYPE',
-        default = 'rgba',
-        choices = ['rgba', 'f16x3', 'f32'],
-        help = 'The kind of data file to cascade',
+        '--format', '-f',
+        metavar = 'FORMAT',
+        default = None,
+        choices = ['png', 'jpg', 'npy', 'fits'],
+        help = 'The format of data files to cascade. If not specified, this will be guessed.',
     )
     parser.add_argument(
         '--start',
@@ -56,24 +56,14 @@ def cascade_impl(settings):
     from .merge import averaging_merger, cascade_images
     from .pyramid import PyramidIO
 
-    pio = PyramidIO(settings.pyramid_dir)
+    pio = PyramidIO(settings.pyramid_dir, default_format=settings.format)
 
     start = settings.start
     if start is None:
         die('currently, you must specify the start layer with the --start option')
 
-    if settings.type == 'rgba':
-        mode = ImageMode.RGBA
-    elif settings.type == 'f16x3':
-        mode = ImageMode.F16x3
-    elif settings.type == 'f32':
-        mode = ImageMode.F32
-    else:
-        die(f'unexpected "type" argument {settings.type}')
-
     cascade_images(
         pio,
-        mode,
         start,
         averaging_merger,
         parallel=settings.parallelism,

--- a/toasty/cli.py
+++ b/toasty/cli.py
@@ -448,7 +448,11 @@ def tile_study_impl(settings):
     img = ImageLoader.create_from_args(settings).load_path(settings.imgpath)
     pio = PyramidIO(settings.outdir, default_format=img.default_format)
     builder = Builder(pio)
-    builder.default_tiled_study_astrometry()
+
+    if img.wcs is None:
+        builder.default_tiled_study_astrometry()
+    else:
+        builder.apply_wcs_info(img.wcs, img.width, img.height)
 
     # Do the thumbnail first since for large inputs it can be the memory high-water mark!
     if settings.placeholder_thumbnail:

--- a/toasty/cli.py
+++ b/toasty/cli.py
@@ -344,7 +344,6 @@ def tile_allsky_impl(settings):
         builder.make_thumbnail_from_other(img)
 
     builder.toast_base(
-        img.mode,
         sampler,
         settings.depth,
         is_planet=is_planet,
@@ -391,7 +390,7 @@ def tile_healpix_impl(settings):
     pio = PyramidIO(settings.outdir, default_format='npy')
     sampler = healpix_fits_file_sampler(settings.fitspath)
     builder = Builder(pio)
-    builder.toast_base(ImageMode.F32, sampler, settings.depth)
+    builder.toast_base(sampler, settings.depth)
     builder.write_index_rel_wtml()
 
     print(f'Successfully tiled input "{settings.fitspath}" at level {builder.imgset.tile_levels}.')

--- a/toasty/cli.py
+++ b/toasty/cli.py
@@ -140,7 +140,7 @@ def multi_tan_make_data_tiles_impl(settings):
     from .multi_tan import MultiTanDataSource
     from .pyramid import PyramidIO
 
-    pio = PyramidIO(settings.outdir)
+    pio = PyramidIO(settings.outdir, default_format='npy')
     ds = MultiTanDataSource(settings.paths, hdu_index=settings.hdu_index)
     ds.compute_global_pixelization()
 
@@ -398,7 +398,7 @@ def tile_healpix_impl(settings):
     from .pyramid import PyramidIO
     from .samplers import healpix_fits_file_sampler
 
-    pio = PyramidIO(settings.outdir)
+    pio = PyramidIO(settings.outdir, default_format='npy')
     sampler = healpix_fits_file_sampler(settings.fitspath)
     builder = Builder(pio)
     builder.toast_base(ImageMode.F32, sampler, settings.depth)
@@ -446,7 +446,7 @@ def tile_study_impl(settings):
     from .pyramid import PyramidIO
 
     img = ImageLoader.create_from_args(settings).load_path(settings.imgpath)
-    pio = PyramidIO(settings.outdir)
+    pio = PyramidIO(settings.outdir, default_format=img.default_format)
     builder = Builder(pio)
     builder.default_tiled_study_astrometry()
 

--- a/toasty/image.py
+++ b/toasty/image.py
@@ -453,9 +453,9 @@ class Image(object):
         ----------
         pil_img : :class:`PIL.Image.Image`
             The source image.
-        wcs : :class:`~astropy.wcs.WCS`
+        wcs : :class:`~astropy.wcs.WCS`, optional
             The WCS coordinate system for the image.
-        default_format : str
+        default_format : str, optional
             The default format to use when writing the image if none is
             specified explicitly.
 
@@ -494,9 +494,9 @@ class Image(object):
             The source data. This should either be a 2-d floating point array a
             3-d floating-point or uint8 array with shape (3, ny, nx), or a 3-d
             uint8 array with shape (4, ny, nx).
-        wcs : :class:`~astropy.wcs.WCS`
+        wcs : :class:`~astropy.wcs.WCS`, optional
             The WCS coordinate system for the image.
-        default_format : str
+        default_format : str, optional
             The default format to use when writing the image if none is
             specified explicitly. If not specified, this is automatically
             chosen at write time based on the array type.

--- a/toasty/image.py
+++ b/toasty/image.py
@@ -22,10 +22,18 @@ from enum import Enum
 from PIL import Image as pil_image
 import numpy as np
 import sys
-from astropy.io import fits
+
+try:
+    from astropy.io import fits
+    ASTROPY_INSTALLED = True
+except ImportError:
+    ASTROPY_INSTALLED = False
 
 PIL_FORMATS = {'jpg': 'JPEG', 'png': 'PNG'}
-SUPPORTED_FORMATS = list(PIL_FORMATS) + ['npy', 'fits']
+SUPPORTED_FORMATS = list(PIL_FORMATS) + ['npy']
+
+if ASTROPY_INSTALLED:
+    SUPPORTED_FORMATS += ['fits']
 
 
 class ImageMode(Enum):

--- a/toasty/image.py
+++ b/toasty/image.py
@@ -473,7 +473,8 @@ class Image(object):
             The WCS coordinate system for the image.
         default_format : str
             The default format to use when writing the image if none is
-            specified explicitly.
+            specified explicitly. If not specified, the default format is set
+            depending on the mode.
 
         Returns
         -------
@@ -514,7 +515,8 @@ class Image(object):
             The WCS coordinate system for the image.
         default_format : str
             The default format to use when writing the image if none is
-            specified explicitly.
+            specified explicitly. If not specified, the default format is set
+            depending on the mode.
 
         Returns
         -------
@@ -627,7 +629,13 @@ class Image(object):
 
     @property
     def default_format(self):
-        return self._default_format
+        if self._default_format is None:
+            if self.mode in (ImageMode.RGB, ImageMode.RGBA):
+                return 'png'
+            elif self.mode in (ImageMode.F32, ImageMode.F16x3):
+                return 'npy'
+        else:
+            return self._default_format
 
     @default_format.setter
     def default_format(self, value):

--- a/toasty/image.py
+++ b/toasty/image.py
@@ -97,6 +97,8 @@ class ImageMode(Enum):
             mask_mode = ImageMode.RGBA
         elif self == ImageMode.F32:
             arr = np.empty((buf_height, buf_width), dtype=np.float32)
+        elif self == ImageMode.F64:
+            arr = np.empty((buf_height, buf_width), dtype=np.float64)
         elif self == ImageMode.F16x3:
             arr = np.empty((buf_height, buf_width, 3), dtype=np.float16)
         else:

--- a/toasty/image.py
+++ b/toasty/image.py
@@ -530,8 +530,12 @@ class Image(object):
         array = np.atleast_2d(array)
         array_ok = False
 
+        # NOTE: we need to be careful to allow both little and big-endian data,
+        # hence the check of .kind and .itemsize.
         if mode == ImageMode.F32:
-            array_ok = (array.ndim == 2 and array.dtype == np.dtype(np.float32))
+            array_ok = (array.ndim == 2 and array.dtype.kind == 'f' and array.dtype.itemsize == 4)
+        elif mode == ImageMode.F64:
+            array_ok = (array.ndim == 2 and array.dtype.kind == 'f' and array.dtype.itemsize == 8)
         elif mode == ImageMode.RGB:
             array_ok = (array.ndim == 3 and array.shape[2] == 3 and array.dtype == np.dtype(np.uint8))
         elif mode == ImageMode.RGBA:

--- a/toasty/merge.py
+++ b/toasty/merge.py
@@ -59,7 +59,7 @@ def averaging_merger(data):
         return np.nanmean(data.reshape(s), axis=(1, 3)).astype(data.dtype)
 
 
-def cascade_images(pio, mode, start, merger, parallel=None, cli_progress=False):
+def cascade_images(pio, start, merger, parallel=None, cli_progress=False):
     """Downsample image tiles all the way to the top of the pyramid.
 
     This function will walk the tiles in the tile pyramid, merging child tile
@@ -69,8 +69,6 @@ def cascade_images(pio, mode, start, merger, parallel=None, cli_progress=False):
     ----------
     pio : :class:`toasty.pyramid.PyramidIO`
         An object managing I/O on the tiles in the pyramid.
-    mode : :class:`toasty.image.ImageMode`
-        The image mode (i.e., RGB or scientific) to process.
     start : nonnegative integer
         The depth at which to start the cascade process. It is assumed that
         the tiles *at this depth* are already populated by some other means.
@@ -91,12 +89,12 @@ def cascade_images(pio, mode, start, merger, parallel=None, cli_progress=False):
     parallel = resolve_parallelism(parallel)
 
     if parallel > 1:
-        _cascade_images_parallel(pio, mode, start, merger, cli_progress, parallel)
+        _cascade_images_parallel(pio, start, merger, cli_progress, parallel)
     else:
-        _cascade_images_serial(pio, mode, start, merger, cli_progress)
+        _cascade_images_serial(pio, start, merger, cli_progress)
 
 
-def _cascade_images_serial(pio, mode, start, merger, cli_progress):
+def _cascade_images_serial(pio, start, merger, cli_progress):
     buf = None
     SLICES = [
         (slice(None, 256), slice(None, 256)),
@@ -114,10 +112,10 @@ def _cascade_images_serial(pio, mode, start, merger, cli_progress):
             # processed.
             children = pyramid.pos_children(pos)
 
-            img0 = pio.read_image(children[0], mode, default='none')
-            img1 = pio.read_image(children[1], mode, default='none')
-            img2 = pio.read_image(children[2], mode, default='none')
-            img3 = pio.read_image(children[3], mode, default='none')
+            img0 = pio.read_image(children[0], default='none')
+            img1 = pio.read_image(children[1], default='none')
+            img2 = pio.read_image(children[2], default='none')
+            img3 = pio.read_image(children[3], default='none')
 
             if img0 is None and img1 is None and img2 is None and img3 is None:
                 progress.update(1)
@@ -129,12 +127,14 @@ def _cascade_images_serial(pio, mode, start, merger, cli_progress):
             for slidx, subimg in zip(SLICES, (img0, img1, img2, img3)):
                 if subimg is not None:
                     if buf is None:
-                        buf = mode.make_maskable_buffer(512, 512)
+                        buf = subimg.mode.make_maskable_buffer(512, 512)
                         buf.clear()
 
-                    buf.asarray()[slidx] = subimg.asarray()
+                    subimg.fill_into_maskable_buffer(buf,
+                                                     slice(None), slice(None),
+                                                     *slidx)
 
-            merged = Image.from_array(mode, merger(buf.asarray()))
+            merged = Image.from_array(merger(buf.asarray()))
             pio.write_image(pos, merged)
             progress.update(1)
 
@@ -142,7 +142,7 @@ def _cascade_images_serial(pio, mode, start, merger, cli_progress):
         print()
 
 
-def _cascade_images_parallel(pio, mode, start, merger, cli_progress, parallel):
+def _cascade_images_parallel(pio, start, merger, cli_progress, parallel):
     """Parallelized cascade operation
 
     At the moment, we require fork-based multiprocessing because the PyramidIO
@@ -176,7 +176,7 @@ def _cascade_images_parallel(pio, mode, start, merger, cli_progress, parallel):
     for _ in range(parallel):
         w = mp.Process(
             target=_mp_cascade_worker,
-            args=(done_queue, ready_queue, pio, merger, mode),
+            args=(done_queue, ready_queue, pio, merger),
         )
         w.daemon = True
         w.start()
@@ -247,7 +247,7 @@ def _mp_cascade_dispatcher(done_queue, ready_queue, n_todo, cli_progress):
         print()
 
 
-def _mp_cascade_worker(done_queue, ready_queue, pio, merger, mode):
+def _mp_cascade_worker(done_queue, ready_queue, pio, merger):
     """
     Process tiles that are ready.
     """
@@ -273,10 +273,10 @@ def _mp_cascade_worker(done_queue, ready_queue, pio, merger, mode):
         # processed.
         children = pyramid.pos_children(pos)
 
-        img0 = pio.read_image(children[0], mode, default='none')
-        img1 = pio.read_image(children[1], mode, default='none')
-        img2 = pio.read_image(children[2], mode, default='none')
-        img3 = pio.read_image(children[3], mode, default='none')
+        img0 = pio.read_image(children[0], default='none')
+        img1 = pio.read_image(children[1], default='none')
+        img2 = pio.read_image(children[2], default='none')
+        img3 = pio.read_image(children[3], default='none')
 
         if img0 is None and img1 is None and img2 is None and img3 is None:
             pass  # No data here; ignore
@@ -287,12 +287,14 @@ def _mp_cascade_worker(done_queue, ready_queue, pio, merger, mode):
             for slidx, subimg in zip(SLICES, (img0, img1, img2, img3)):
                 if subimg is not None:
                     if buf is None:
-                        buf = mode.make_maskable_buffer(512, 512)
+                        buf = subimg.mode.make_maskable_buffer(512, 512)
                         buf.clear()
 
-                    buf.asarray()[slidx] = subimg.asarray()
+                    subimg.fill_into_maskable_buffer(buf,
+                                                     slice(None), slice(None),
+                                                     *slidx)
 
-            merged = Image.from_array(mode, merger(buf.asarray()))
+            merged = Image.from_array(merger(buf.asarray()))
             pio.write_image(pos, merged)
 
         done_queue.put(pos)

--- a/toasty/multi_tan.py
+++ b/toasty/multi_tan.py
@@ -397,7 +397,7 @@ class MultiTanDataSource(object):
                     ###      f'{img_overlap_x0} {img_overlap_y0} {img_overlap_x1} {img_overlap_y1}')
 
                     pos = Pos(self._tile_levels, ix, iy)
-                    p = pio.tile_path(pos, extension='npy')
+                    p = pio.tile_path(pos)
 
                     try:
                         a = np.load(p)

--- a/toasty/multi_wcs.py
+++ b/toasty/multi_wcs.py
@@ -214,7 +214,7 @@ class MultiWcsProcessor(object):
 
                 # Once again, FITS coordinates have y=0 at the bottom and our
                 # coordinates have y=0 at the top, so we need a vertical flip.
-                image = Image.from_array(ImageMode.F32, array.astype(np.float32)[::-1])
+                image = Image.from_array(array.astype(np.float32)[::-1])
 
                 for pos, width, height, image_x, image_y, tile_x, tile_y in desc.sub_tiling.generate_populated_positions():
                     iy_idx = slice(image_y, image_y + height)
@@ -291,7 +291,7 @@ def _mp_tile_worker(queue, pio, reproject_function, kwargs):
 
         # Once again, FITS coordinates have y=0 at the bottom and our
         # coordinates have y=0 at the top, so we need a vertical flip.
-        image = Image.from_array(ImageMode.F32, array.astype(np.float32)[::-1])
+        image = Image.from_array(array.astype(np.float32)[::-1])
 
         for pos, width, height, image_x, image_y, tile_x, tile_y in desc.sub_tiling.generate_populated_positions():
             iy_idx = slice(image_y, image_y + height)

--- a/toasty/multi_wcs.py
+++ b/toasty/multi_wcs.py
@@ -222,7 +222,7 @@ class MultiWcsProcessor(object):
                     by_idx = slice(tile_y, tile_y + height)
                     bx_idx = slice(tile_x, tile_x + width)
 
-                    with pio.update_image(pos, image.mode, default='masked') as basis:
+                    with pio.update_image(pos, masked_mode=image.mode, default='masked') as basis:
                         image.update_into_maskable_buffer(basis, iy_idx, ix_idx, by_idx, bx_idx)
 
                     progress.update(1)
@@ -299,5 +299,5 @@ def _mp_tile_worker(queue, pio, reproject_function, kwargs):
             by_idx = slice(tile_y, tile_y + height)
             bx_idx = slice(tile_x, tile_x + width)
 
-            with pio.update_image(pos, image.mode, default='masked') as basis:
+            with pio.update_image(pos, masked_mode=image.mode, default='masked') as basis:
                 image.update_into_maskable_buffer(basis, iy_idx, ix_idx, by_idx, bx_idx)

--- a/toasty/pipeline.py
+++ b/toasty/pipeline.py
@@ -680,7 +680,7 @@ class BitmapInputImage(InputImage):
             tiling.apply_to_imageset(imgset)
 
             # Cascade to create the coarser tiles
-            cascade_images(pio, ImageMode.RGBA, imgset.tile_levels, averaging_merger)
+            cascade_images(pio, imgset.tile_levels, averaging_merger)
 
             imgset.url = pio.get_path_scheme() + '.png'
             imgset.file_type = '.png'

--- a/toasty/pyramid.py
+++ b/toasty/pyramid.py
@@ -192,6 +192,9 @@ class PyramidIO(object):
 
     def __init__(self, base_dir, scheme='L/Y/YX', default_format='png'):
 
+        # TODO: could auto-detect default_format based on tiles inside
+        # pyramid directory instead of defaulting to PNG?
+
         self._base_dir = base_dir
         self._default_format = default_format
 

--- a/toasty/pyramid.py
+++ b/toasty/pyramid.py
@@ -185,7 +185,7 @@ class PyramidIO(object):
     base_dir : str
         The base directory containing the tiles
     scheme : str
-        The tile organizatio scheme, should be either 'L/Y/YX' or 'LXY'
+        The tile organization scheme, should be either 'L/Y/YX' or 'LXY'
     default_format : str
         The file format to assume for the tiles if none is specified when
         reading/writing tiles. If not specified, and base_dir exists and

--- a/toasty/pyramid.py
+++ b/toasty/pyramid.py
@@ -289,8 +289,6 @@ class PyramidIO(object):
         """
         p = self.tile_path(pos, format=format)
 
-        print('read_image', format, p)
-
         loader = ImageLoader()
         loader.desired_mode = mode
 

--- a/toasty/pyramid.py
+++ b/toasty/pyramid.py
@@ -30,7 +30,7 @@ from contextlib import contextmanager
 import numpy as np
 import os.path
 
-from .image import ImageLoader
+from .image import ImageLoader, SUPPORTED_FORMATS
 
 Pos = namedtuple('Pos', 'n x y')
 
@@ -187,15 +187,28 @@ class PyramidIO(object):
         The tile organizatio scheme, should be either 'L/Y/YX' or 'LXY'
     default_format : str
         The file format to assume for the tiles if none is specified when
-        reading/writing tiles. Defaults to 'png'.
+        reading/writing tiles. If not specified, and base_dir exists and
+        contains files, these are used to guess default_format. Otherwise
+        defaults to 'png'.
     """
 
-    def __init__(self, base_dir, scheme='L/Y/YX', default_format='png'):
+    def __init__(self, base_dir, scheme='L/Y/YX', default_format=None):
 
         # TODO: could auto-detect default_format based on tiles inside
         # pyramid directory instead of defaulting to PNG?
 
         self._base_dir = base_dir
+
+        if default_format is None and os.path.exists(base_dir) and os.path.isdir(base_dir):
+            for _, _, filenames in os.walk(base_dir):
+                for filename in filenames:
+                    extension = os.path.splitext(filename)[1][1:]
+                    if extension in SUPPORTED_FORMATS:
+                        default_format = extension
+                        break
+                if default_format is not None:
+                    break
+
         self._default_format = default_format
 
         if scheme == 'L/Y/YX':

--- a/toasty/pyramid.py
+++ b/toasty/pyramid.py
@@ -176,7 +176,19 @@ def generate_pos(depth):
 
 
 class PyramidIO(object):
-    """Manage I/O on a tile pyramid."""
+    """
+    Manage I/O on a tile pyramid.
+
+    Parameters
+    ----------
+    base_dir : str
+        The base directory containing the tiles
+    scheme : str
+        The tile organizatio scheme, should be either 'L/Y/YX' or 'LXY'
+    default_format : str
+        The file format to assume for the tiles if none is specified when
+        reading/writing tiles. Defaults to 'png'.
+    """
 
     def __init__(self, base_dir, scheme='L/Y/YX', default_format='png'):
 
@@ -312,7 +324,7 @@ class PyramidIO(object):
 
         """
         p = self.tile_path(pos, format=format or self._default_format)
-        image.save_default(p, format=format or self._default_format)
+        image.save(p, format=format or self._default_format)
 
     @contextmanager
     def update_image(self, pos, mode, default='none', format=None):

--- a/toasty/pyramid.py
+++ b/toasty/pyramid.py
@@ -208,6 +208,8 @@ class PyramidIO(object):
                         break
                 if default_format is not None:
                     break
+            else:
+                default_format = 'png'
 
         self._default_format = default_format
 
@@ -284,7 +286,7 @@ class PyramidIO(object):
         """
         return self._scheme
 
-    def read_image(self, pos, mode, default='none', format=None):
+    def read_image(self, pos, default='none', format=None):
         """
         Read an Image for the specified tile position.
 
@@ -292,9 +294,6 @@ class PyramidIO(object):
         ----------
         pos : :class:`Pos`
             The tile position to read.
-        mode : :class:`toasty.image.ImageMode`
-            The image data mode to read. This will affect the file extension probed
-            and the mode of the returned image.
         default : str, defaults to "none"
             What to do if the specified tile file does not exist. If this is
             "none", ``None`` will be returned instead of an image. If this is
@@ -306,7 +305,6 @@ class PyramidIO(object):
         p = self.tile_path(pos, format=format)
 
         loader = ImageLoader()
-        loader.desired_mode = mode
 
         try:
             img = loader.load_path(p)
@@ -323,10 +321,9 @@ class PyramidIO(object):
             else:
                 raise ValueError('unexpected value for "default": {!r}'.format(default))
 
-        assert img.mode == mode
         return img
 
-    def write_image(self, pos, image, format=None):
+    def write_image(self, pos, image, format=None, mode=None):
         """Write an Image for the specified tile position.
 
         Parameters
@@ -338,7 +335,7 @@ class PyramidIO(object):
 
         """
         p = self.tile_path(pos, format=format or self._default_format)
-        image.save(p, format=format or self._default_format)
+        image.save(p, format=format or self._default_format, mode=mode)
 
     @contextmanager
     def update_image(self, pos, mode, default='none', format=None):

--- a/toasty/study.py
+++ b/toasty/study.py
@@ -320,7 +320,11 @@ class StudyTiling(object):
         if image.width != self._width:
             raise ValueError('width of image to be sampled does not match tiling')
 
+        # TODO: ideally make_maskable_buffer should be a method
+        # on the Image class which could then avoid having to
+        # manually transfer _format.
         buffer = image.mode.make_maskable_buffer(256, 256)
+        buffer._default_format = image._default_format
 
         with tqdm(total=self.count_populated_positions(), disable=not cli_progress) as progress:
             for pos, width, height, image_x, image_y, tile_x, tile_y in self.generate_populated_positions():

--- a/toasty/tests/test_multi_tan.py
+++ b/toasty/tests/test_multi_tan.py
@@ -85,7 +85,7 @@ class TestMultiTan(object):
         assert_xml_elements_equal(folder, expected)
 
         from ..pyramid import PyramidIO
-        pio = PyramidIO(self.work_path('basic'))
+        pio = PyramidIO(self.work_path('basic'), default_format='npy')
         percentiles = ds.generate_deepest_layer_numpy(pio)
 
         # These are all hardcoded parameters of this test dataset, derived

--- a/toasty/tests/test_toast.py
+++ b/toasty/tests/test_toast.py
@@ -151,7 +151,6 @@ def image_test(expected, actual, err_msg):
 class TestSampleLayer(object):
     def setup_method(self, method):
         self.base = mkdtemp()
-        print(self.base)
         self.pio = PyramidIO(self.base)
 
     # def teardown_method(self, method):
@@ -207,8 +206,8 @@ class TestSampleLayer(object):
         from ..samplers import healpix_fits_file_sampler
 
         sampler = healpix_fits_file_sampler(test_path('earth_healpix_gal.fits'))
-        sample_layer(self.pio, ImageMode.F32, sampler, 1, format='npy')
-        self.verify_level1(ImageMode.F32, format='npy')
+        sample_layer(self.pio, ImageMode.F32, sampler, 1, format='fits')
+        self.verify_level1(ImageMode.F32, format='fits')
 
 
 class TestCliBasic(object):

--- a/toasty/tests/test_toast.py
+++ b/toasty/tests/test_toast.py
@@ -190,7 +190,7 @@ class TestSampleLayer(object):
 
         img = ImageLoader().load_path(test_path('Equirectangular_projection_SW-tweaked.exr'))
         sampler = plate_carree_sampler(img.asarray())
-        sample_layer(self.pio, ImageMode.F16x3, sampler, 1)
+        sample_layer(self.pio, ImageMode.F16x3, sampler, 1, format='npy')
         f16x3_to_rgb(self.pio, 1, parallel=1)
         self.verify_level1(ImageMode.RGB)
 

--- a/toasty/tests/test_toast.py
+++ b/toasty/tests/test_toast.py
@@ -27,7 +27,7 @@ except ImportError:
 
 from . import test_path
 from .. import cli, toast
-from ..image import ImageLoader, ImageMode
+from ..image import ImageLoader
 from ..pyramid import Pos, PyramidIO
 from ..toast import sample_layer
 from ..transform import f16x3_to_rgb
@@ -173,7 +173,7 @@ class TestSampleLayer(object):
         from ..samplers import plate_carree_sampler
         img = ImageLoader().load_path(test_path('Equirectangular_projection_SW-tweaked.jpg'))
         sampler = plate_carree_sampler(img.asarray())
-        sample_layer(self.pio, ImageMode.RGB, sampler, 1, format='png')
+        sample_layer(self.pio, sampler, 1, format='png')
         self.verify_level1()
 
     def test_plate_carree_ecliptic(self):
@@ -181,7 +181,7 @@ class TestSampleLayer(object):
 
         img = ImageLoader().load_path(test_path('tess_platecarree_ecliptic_512.jpg'))
         sampler = plate_carree_ecliptic_sampler(img.asarray())
-        sample_layer(self.pio, ImageMode.RGB, sampler, 1, format='png')
+        sample_layer(self.pio, sampler, 1, format='png')
         self.verify_level1(ref='tess')
 
     @pytest.mark.skipif('not HAS_OPENEXR')
@@ -190,7 +190,7 @@ class TestSampleLayer(object):
 
         img = ImageLoader().load_path(test_path('Equirectangular_projection_SW-tweaked.exr'))
         sampler = plate_carree_sampler(img.asarray())
-        sample_layer(self.pio, ImageMode.F16x3, sampler, 1, format='npy')
+        sample_layer(self.pio, sampler, 1, format='npy')
         f16x3_to_rgb(self.pio, 1, parallel=1)
         self.verify_level1()
 
@@ -199,7 +199,7 @@ class TestSampleLayer(object):
         from ..samplers import healpix_fits_file_sampler
 
         sampler = healpix_fits_file_sampler(test_path('earth_healpix_equ.fits'))
-        sample_layer(self.pio, ImageMode.F32, sampler, 1, format='npy')
+        sample_layer(self.pio, sampler, 1, format='npy')
         self.verify_level1(format='npy', expected_2d=True)
 
     @pytest.mark.skipif('not HAS_ASTRO')
@@ -207,7 +207,7 @@ class TestSampleLayer(object):
         from ..samplers import healpix_fits_file_sampler
 
         sampler = healpix_fits_file_sampler(test_path('earth_healpix_gal.fits'))
-        sample_layer(self.pio, ImageMode.F32, sampler, 1, format='fits')
+        sample_layer(self.pio, sampler, 1, format='fits')
         self.verify_level1(format='fits', expected_2d=True)
 
 

--- a/toasty/tests/test_toast.py
+++ b/toasty/tests/test_toast.py
@@ -151,12 +151,13 @@ def image_test(expected, actual, err_msg):
 class TestSampleLayer(object):
     def setup_method(self, method):
         self.base = mkdtemp()
+        print(self.base)
         self.pio = PyramidIO(self.base)
 
-    def teardown_method(self, method):
-        rmtree(self.base)
+    # def teardown_method(self, method):
+    #     rmtree(self.base)
 
-    def verify_level1(self, mode, ref='earth_toasted_sky'):
+    def verify_level1(self, mode, ref='earth_toasted_sky', format=None):
         for n, x, y in [(1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1)]:
             ref_path = test_path(ref, str(n), str(y), "%i_%i.png" % (y, x))
             expected = ImageLoader().load_path(ref_path).asarray()
@@ -164,16 +165,15 @@ class TestSampleLayer(object):
                 expected = expected.mean(axis=2)
 
             pos = Pos(n=n, x=x, y=y)
-            observed = self.pio.read_image(pos, mode).asarray()
+            observed = self.pio.read_image(pos, mode, format=format).asarray()
 
             image_test(expected, observed, 'Failed for %s' % ref_path)
 
     def test_plate_carree(self):
         from ..samplers import plate_carree_sampler
-
         img = ImageLoader().load_path(test_path('Equirectangular_projection_SW-tweaked.jpg'))
         sampler = plate_carree_sampler(img.asarray())
-        sample_layer(self.pio, ImageMode.RGB, sampler, 1)
+        sample_layer(self.pio, ImageMode.RGB, sampler, 1, format='png')
         self.verify_level1(ImageMode.RGB)
 
     def test_plate_carree_ecliptic(self):
@@ -181,7 +181,7 @@ class TestSampleLayer(object):
 
         img = ImageLoader().load_path(test_path('tess_platecarree_ecliptic_512.jpg'))
         sampler = plate_carree_ecliptic_sampler(img.asarray())
-        sample_layer(self.pio, ImageMode.RGB, sampler, 1)
+        sample_layer(self.pio, ImageMode.RGB, sampler, 1, format='png')
         self.verify_level1(ImageMode.RGB, ref='tess')
 
     @pytest.mark.skipif('not HAS_OPENEXR')
@@ -199,16 +199,16 @@ class TestSampleLayer(object):
         from ..samplers import healpix_fits_file_sampler
 
         sampler = healpix_fits_file_sampler(test_path('earth_healpix_equ.fits'))
-        sample_layer(self.pio, ImageMode.F32, sampler, 1)
-        self.verify_level1(ImageMode.F32)
+        sample_layer(self.pio, ImageMode.F32, sampler, 1, format='npy')
+        self.verify_level1(ImageMode.F32, format='npy')
 
     @pytest.mark.skipif('not HAS_ASTRO')
     def test_healpix_gal(self):
         from ..samplers import healpix_fits_file_sampler
 
         sampler = healpix_fits_file_sampler(test_path('earth_healpix_gal.fits'))
-        sample_layer(self.pio, ImageMode.F32, sampler, 1)
-        self.verify_level1(ImageMode.F32)
+        sample_layer(self.pio, ImageMode.F32, sampler, 1, format='npy')
+        self.verify_level1(ImageMode.F32, format='npy')
 
 
 class TestCliBasic(object):

--- a/toasty/tests/test_toast.py
+++ b/toasty/tests/test_toast.py
@@ -153,8 +153,8 @@ class TestSampleLayer(object):
         self.base = mkdtemp()
         self.pio = PyramidIO(self.base)
 
-    # def teardown_method(self, method):
-    #     rmtree(self.base)
+    def teardown_method(self, method):
+        rmtree(self.base)
 
     def verify_level1(self, mode, ref='earth_toasted_sky', format=None):
         for n, x, y in [(1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1)]:

--- a/toasty/toast.py
+++ b/toasty/toast.py
@@ -460,7 +460,7 @@ def _sample_layer_serial(pio, mode, format, sampler, depth, cli_progress):
                 tile.increasing,
             )
             sampled_data = sampler(lon, lat)
-            pio.write_image(tile.pos, Image.from_array(mode, sampled_data), format=format)
+            pio.write_image(tile.pos, Image.from_array(sampled_data), format=format)
             progress.update(1)
 
     if cli_progress:
@@ -526,4 +526,4 @@ def _mp_sample_worker(queue, pio, sampler, mode, format):
             tile.increasing,
         )
         sampled_data = sampler(lon, lat)
-        pio.write_image(tile.pos, Image.from_array(mode, sampled_data), format=format)
+        pio.write_image(tile.pos, Image.from_array(sampled_data), format=format)

--- a/toasty/toast.py
+++ b/toasty/toast.py
@@ -460,7 +460,6 @@ def _sample_layer_serial(pio, mode, format, sampler, depth, cli_progress):
                 tile.increasing,
             )
             sampled_data = sampler(lon, lat)
-            print("FORMAT", format, mode)
             pio.write_image(tile.pos, Image.from_array(mode, sampled_data), format=format)
             progress.update(1)
 

--- a/toasty/toast.py
+++ b/toasty/toast.py
@@ -412,7 +412,7 @@ def generate_tiles(depth, bottom_only=True):
             yield item
 
 
-def sample_layer(pio, mode, sampler, depth, parallel=None, cli_progress=False,
+def sample_layer(pio, sampler, depth, parallel=None, cli_progress=False,
                  format=None):
     """Generate a layer of the TOAST tile pyramid through direct sampling.
 
@@ -421,8 +421,6 @@ def sample_layer(pio, mode, sampler, depth, parallel=None, cli_progress=False,
     pio : :class:`toasty.pyramid.PyramidIO`
         A :class:`~toasty.pyramid.PyramidIO` instance to manage the I/O with
         the tiles in the tile pyramid.
-    mode : :class:`toasty.image.ImageMode`
-        The image mode of this data source.
     sampler : callable
         The sampler callable that will produce data for tiling.
     depth : int
@@ -443,12 +441,12 @@ def sample_layer(pio, mode, sampler, depth, parallel=None, cli_progress=False,
     parallel = resolve_parallelism(parallel)
 
     if parallel > 1:
-        _sample_layer_parallel(pio, mode, format, sampler, depth, cli_progress, parallel)
+        _sample_layer_parallel(pio, format, sampler, depth, cli_progress, parallel)
     else:
-        _sample_layer_serial(pio, mode, format, sampler, depth, cli_progress)
+        _sample_layer_serial(pio, format, sampler, depth, cli_progress)
 
 
-def _sample_layer_serial(pio, mode, format, sampler, depth, cli_progress):
+def _sample_layer_serial(pio, format, sampler, depth, cli_progress):
     with tqdm(total=tiles_at_depth(depth), disable=not cli_progress) as progress:
         for tile in generate_tiles(depth, bottom_only=True):
             lon, lat = subsample(
@@ -467,7 +465,7 @@ def _sample_layer_serial(pio, mode, format, sampler, depth, cli_progress):
         print()
 
 
-def _sample_layer_parallel(pio, mode, format, sampler, depth, cli_progress, parallel):
+def _sample_layer_parallel(pio, format, sampler, depth, cli_progress, parallel):
     import multiprocessing as mp
 
     queue = mp.Queue(maxsize = 2 * parallel)
@@ -477,7 +475,7 @@ def _sample_layer_parallel(pio, mode, format, sampler, depth, cli_progress, para
     workers = []
 
     for _ in range(parallel):
-        w = mp.Process(target=_mp_sample_worker, args=(queue, pio, sampler, mode, format))
+        w = mp.Process(target=_mp_sample_worker, args=(queue, pio, sampler, format))
         w.daemon = True
         w.start()
         workers.append(w)
@@ -503,7 +501,7 @@ def _mp_sample_dispatcher(queue, depth, cli_progress):
     queue.close()
 
 
-def _mp_sample_worker(queue, pio, sampler, mode, format):
+def _mp_sample_worker(queue, pio, sampler, format):
     """
     Process tiles on the queue.
     """

--- a/toasty/transform.py
+++ b/toasty/transform.py
@@ -100,7 +100,7 @@ def _float_to_rgb_do_one(buf, pos, pio, read_mode, transform):
     Do one float-to-RGB job. This problem is embarassingly parallel so we can
     share code between the serial and parallel implementations.
     """
-    img = pio.read_image(pos, read_mode)
+    img = pio.read_image(pos, read_mode, format='npy')
     if img is None:
         return
 
@@ -121,4 +121,4 @@ def _float_to_rgb_do_one(buf, pos, pio, read_mode, transform):
         buf[...,3] = 255 * valid
 
     rgb = Image.from_array(ImageMode.RGBA, buf)
-    pio.write_image(pos, rgb)
+    pio.write_image(pos, rgb, format='png')

--- a/toasty/transform.py
+++ b/toasty/transform.py
@@ -100,7 +100,7 @@ def _float_to_rgb_do_one(buf, pos, pio, read_mode, transform):
     Do one float-to-RGB job. This problem is embarassingly parallel so we can
     share code between the serial and parallel implementations.
     """
-    img = pio.read_image(pos, read_mode, format='npy')
+    img = pio.read_image(pos, format='npy')
     if img is None:
         return
 
@@ -120,5 +120,5 @@ def _float_to_rgb_do_one(buf, pos, pio, read_mode, transform):
         buf[...,:3] = mapped
         buf[...,3] = 255 * valid
 
-    rgb = Image.from_array(ImageMode.RGBA, buf)
-    pio.write_image(pos, rgb, format='png')
+    rgb = Image.from_array(buf)
+    pio.write_image(pos, rgb, format='png', mode=ImageMode.RGB)


### PR DESCRIPTION
This is very much a WIP for now but the goal is to make the ``toasty`` commands work seamlessly with FITS files. To start with I wanted to find the minimal changes that would allow ``tile-study`` to 'work' with FITS files - to do this I had to introduce a new property called ``format`` on ``PyramidIO`` and ``Image``, which can be set to the I/O format to use - this is needed because now multiple formats (in this case Numpy and FITS) could represent F32 or F64 data.

Things to wrap up in this PR:

* [x] fix existing implementation to pass all tests
* [x] fix cascade sub-command (currently not generating any images, related to default PymamidIO format)
* [x] automatically set pointing information on output based on WCS
* [x] add tests

Things that could be done in follow-up PRs:

* [ ] improve how we recognize FITS files (not just extension)
* [ ] explicitly only allow TAN FITS files for now
* [ ] think of ways of dealing with non-TAN projections on-the-fly
* [ ] add WCS to FITS tiles
* [ ] automatically parse AVM meta-data from RGB images and set Image.wcs

Not everything has to be done in this PR of course, but this is just a brain dump.

@pkgw - is there anything else you'd like to see done here?