### PR TITLE
toasty/merge.py: oops, clear our downsampling buffer on init

### DIFF
--- a/toasty/merge.py
+++ b/toasty/merge.py
@@ -130,6 +130,7 @@ def _cascade_images_serial(pio, mode, start, merger, cli_progress):
                 if subimg is not None:
                     if buf is None:
                         buf = mode.make_maskable_buffer(512, 512)
+                        buf.clear()
 
                     buf.asarray()[slidx] = subimg.asarray()
 
@@ -287,6 +288,7 @@ def _mp_cascade_worker(done_queue, ready_queue, pio, merger, mode):
                 if subimg is not None:
                     if buf is None:
                         buf = mode.make_maskable_buffer(512, 512)
+                        buf.clear()
 
                     buf.asarray()[slidx] = subimg.asarray()
 


### PR DESCRIPTION
`make_maskable_buffer()` doesn't initialize the buffer, for efficiency. We didn't initialize it either, leading to artifacts in the first few tiles processed.