### PR TITLE
pipeline: get Djangoplicity working for eso.org

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -30,6 +30,10 @@ Python API Reference
    :no-inheritance-diagram:
    :no-inherited-members:
 
+.. automodapi:: toasty.par_util
+   :no-inheritance-diagram:
+   :no-inherited-members:
+
 .. automodapi:: toasty.pipeline
    :no-inheritance-diagram:
    :no-inherited-members:

--- a/docs/api/toasty.par_util.resolve_parallelism.rst
+++ b/docs/api/toasty.par_util.resolve_parallelism.rst
@@ -1,0 +1,6 @@
+resolve_parallelism
+===================
+
+.. currentmodule:: toasty.par_util
+
+.. autofunction:: resolve_parallelism

--- a/docs/api/toasty.pipeline.djangoplicity.DjangoplicityImageSource.rst
+++ b/docs/api/toasty.pipeline.djangoplicity.DjangoplicityImageSource.rst
@@ -13,6 +13,7 @@ DjangoplicityImageSource
       ~DjangoplicityImageSource.deserialize
       ~DjangoplicityImageSource.fetch_candidate
       ~DjangoplicityImageSource.get_config_key
+      ~DjangoplicityImageSource.make_request
       ~DjangoplicityImageSource.process
       ~DjangoplicityImageSource.query_candidates
 
@@ -21,5 +22,6 @@ DjangoplicityImageSource
    .. automethod:: deserialize
    .. automethod:: fetch_candidate
    .. automethod:: get_config_key
+   .. automethod:: make_request
    .. automethod:: process
    .. automethod:: query_candidates

--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -85,6 +85,17 @@ This dictionary should contain the following keys:
   be annotated with, analogous to a YouTube channel. This should be a brief, lowercase,
   URL-friendly name.
 
+The following keys are optional:
+
+- ``search_page_name`` specifies the text used to construct search pagination URLs
+  at the data source. The default is ``page``, which means that search page
+  result URLs look like ``{base_url}/archive/search/page/1/``. As of late 2020,
+  for ``eso.org``, and potentially other sites, the correct setting is ``list``,
+  because the search page URLs look like ``{base_url}/archive/search/list/1/``.
+- ``force_insecure_tls`` should take on a boolean value. If true, it specifies
+  that the TLS-encrypted connections shouldn't be verified. As of late 2020 this
+  is necessary for ``noirlab.edu``.
+
 Astropix Data Source
 --------------------
 

--- a/toasty/par_util.py
+++ b/toasty/par_util.py
@@ -8,12 +8,15 @@
 from __future__ import absolute_import, division, print_function
 
 __all__ = '''
+SHOW_INFORMATIONAL_MESSAGES
 resolve_parallelism
 '''.split()
 
 import multiprocessing as mp
 import os
 import sys
+
+SHOW_INFORMATIONAL_MESSAGES = True
 
 def resolve_parallelism(parallel):
     """Decide what level of parallelism to use.
@@ -31,7 +34,7 @@ def resolve_parallelism(parallel):
     if parallel is None:
         if mp.get_start_method() == 'fork':
             parallel = os.cpu_count()
-            if parallel > 1:
+            if SHOW_INFORMATIONAL_MESSAGES and parallel > 1:
                 print(f'info: parallelizing processing over {parallel} CPUs')
         else:
             parallel = 1

--- a/toasty/pipeline/__init__.py
+++ b/toasty/pipeline/__init__.py
@@ -36,6 +36,8 @@ class NotActionableError(Exception):
     not going to be able to get it into a WWT-compatible form.
 
     """
+    def __init__(self, reason):
+        super(NotActionableError, self).__init__(reason)
 
 
 PIPELINE_IO_LOADERS = {}

--- a/toasty/pipeline/__init__.py
+++ b/toasty/pipeline/__init__.py
@@ -398,12 +398,16 @@ class PipelineManager(object):
 
     def process_todos(self):
         from ..builder import Builder
+        from .. import par_util
         from ..pyramid import PyramidIO
 
         src = self.get_image_source()
         cand_dir = self._path('candidates')
         self._ensure_dir('cache_done')
         baseoutdir = self._ensure_dir('processed')
+
+        # Lame hack to tidy up output slightly
+        par_util.SHOW_INFORMATIONAL_MESSAGES = False
 
         for uniq_id in os.listdir(self._path('cache_todo')):
             cachedir = self._path('cache_todo', uniq_id)

--- a/toasty/pipeline/cli.py
+++ b/toasty/pipeline/cli.py
@@ -149,8 +149,8 @@ def fetch_impl(settings):
                 print('done')
             finally:
                 cdata.close()
-        except NotActionableError:
-            print('not usable')
+        except NotActionableError as e:
+            print('not usable:', e)
             os.rename(os.path.join(cand_dir, cid), os.path.join(rej_dir, cid))
             os.rmdir(cachedir)
 


### PR DESCRIPTION
It turns out that the eso.org installation of Djangoplicity has some differences from the NOIRLab one that mean that we have to add a few more bells and whistles:

- Make TLS-no-verify optional (not strictly required, but good to do)
- The search pagination URLs are different
- Handle gzipped content from the server

We centralize the request-making code a bit to make it easier to support all of these consistently.