### PR TITLE
Support glob arguments on Windows

### DIFF
--- a/ci/azure-build-and-test.yml
+++ b/ci/azure-build-and-test.yml
@@ -103,8 +103,8 @@ jobs:
         pillow \
         pytest-cov \
         pyyaml \
-        tqdm \
-        wwt_data_formats
+        tqdm
+      pip install wwt_data_formats
       pip install -e .
       pytest --cov-report=xml --cov=toasty toasty
     displayName: Test with coverage

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup_args = dict(
         'pillow>=7.0',
         'PyYAML>=5.0',
         'tqdm>=4.0',
-        'wwt_data_formats>=0.7.0',
+        'wwt_data_formats>=0.9.1',
     ],
 
     extras_require = {

--- a/toasty/_libtoasty.pyx
+++ b/toasty/_libtoasty.pyx
@@ -5,8 +5,8 @@ cimport cython
 
 cimport numpy as np
 
-DTYPE = np.float
-ctypedef np.float_t DTYPE_t
+DTYPE = np.float64
+ctypedef np.float64_t DTYPE_t
 
 cdef struct Point:
     DTYPE_t x

--- a/toasty/cli.py
+++ b/toasty/cli.py
@@ -1,5 +1,5 @@
 # -*- mode: python; coding: utf-8 -*-
-# Copyright 2019-2020 the AAS WorldWide Telescope project.
+# Copyright 2019-2021 the AAS WorldWide Telescope project.
 # Licensed under the MIT License.
 
 """Entrypoint for the "toasty" command-line interface.
@@ -17,6 +17,7 @@ warn
 import argparse
 import os.path
 import sys
+from wwt_data_formats.cli import EnsureGlobsExpandedAction
 
 
 # General CLI utilities
@@ -129,6 +130,7 @@ def multi_tan_make_data_tiles_getparser(parser):
     parser.add_argument(
         'paths',
         metavar = 'PATHS',
+        action = EnsureGlobsExpandedAction,
         nargs = '+',
         help = 'The FITS files with image data',
     )

--- a/toasty/pipeline/cli.py
+++ b/toasty/pipeline/cli.py
@@ -16,6 +16,7 @@ from fnmatch import fnmatch
 import glob
 import os.path
 import sys
+from wwt_data_formats.cli import EnsureGlobsExpandedAction
 
 from ..cli import die, warn
 from . import NotActionableError
@@ -61,6 +62,7 @@ def approve_setup_parser(parser):
     parser.add_argument(
         'cand_ids',
         nargs = '+',
+        action = EnsureGlobsExpandedAction,
         metavar = 'IMAGE-ID',
         help = 'Name(s) of image(s) to approve for publication (globs accepted)'
     )
@@ -119,6 +121,7 @@ def fetch_setup_parser(parser):
     parser.add_argument(
         'cand_ids',
         nargs = '+',
+        action = EnsureGlobsExpandedAction,
         metavar = 'CAND-ID',
         help = 'Name(s) of candidate(s) to fetch and prepare for processing (globs accepted)'
     )

--- a/toasty/samplers.py
+++ b/toasty/samplers.py
@@ -1,5 +1,5 @@
 # -*- mode: python; coding: utf-8 -*-
-# Copyright 2013-2020 Chris Beaumont and the AAS WorldWide Telescope project
+# Copyright 2013-2021 Chris Beaumont and the AAS WorldWide Telescope project
 # Licensed under the MIT License.
 
 """
@@ -177,11 +177,11 @@ def plate_carree_sampler(data):
     def vec2pix(lon, lat):
         lon = (lon + np.pi) % (2 * np.pi) - np.pi  # ensure in range [-pi, pi]
         ix = (lon0 - lon) * dx
-        ix = np.round(ix).astype(np.int)
+        ix = np.round(ix).astype(int)
         ix = np.clip(ix, 0, nx - 1)
 
         iy = (lat0 - lat) * dy  # *assume* in range [-pi/2, pi/2]
-        iy = np.round(iy).astype(np.int)
+        iy = np.round(iy).astype(int)
         iy = np.clip(iy, 0, ny - 1)
 
         return data[iy, ix]
@@ -223,11 +223,11 @@ def plate_carree_galactic_sampler(data):
 
         lon = (lon + np.pi) % (2 * np.pi) - np.pi  # ensure in range [-pi, pi]
         ix = (lon0 - lon) * dx
-        ix = np.round(ix).astype(np.int)
+        ix = np.round(ix).astype(int)
         ix = np.clip(ix, 0, nx - 1)
 
         iy = (lat0 - lat) * dy  # *assume* in range [-pi/2, pi/2]
-        iy = np.round(iy).astype(np.int)
+        iy = np.round(iy).astype(int)
         iy = np.clip(iy, 0, ny - 1)
 
         return data[iy, ix]
@@ -269,11 +269,11 @@ def plate_carree_ecliptic_sampler(data):
         lon = lon % (2 * np.pi) - np.pi  # ensure in range [-pi, pi]
 
         ix = (lon0 - lon) * dx
-        ix = np.round(ix).astype(np.int)
+        ix = np.round(ix).astype(int)
         ix = np.clip(ix, 0, nx - 1)
 
         iy = (lat0 - lat) * dy  # *assume* in range [-pi/2, pi/2]
-        iy = np.round(iy).astype(np.int)
+        iy = np.round(iy).astype(int)
         iy = np.clip(iy, 0, ny - 1)
 
         return data[iy, ix]
@@ -313,11 +313,11 @@ def plate_carree_planet_sampler(data):
     def vec2pix(lon, lat):
         lon = (lon + np.pi) % (2 * np.pi) - np.pi  # ensure in range [-pi, pi]
         ix = (lon - lon0) * dx
-        ix = np.round(ix).astype(np.int)
+        ix = np.round(ix).astype(int)
         ix = np.clip(ix, 0, nx - 1)
 
         iy = (lat0 - lat) * dy  # *assume* in range [-pi/2, pi/2]
-        iy = np.round(iy).astype(np.int)
+        iy = np.round(iy).astype(int)
         iy = np.clip(iy, 0, ny - 1)
 
         return data[iy, ix]

--- a/toasty/study.py
+++ b/toasty/study.py
@@ -1,5 +1,5 @@
 # -*- mode: python; coding: utf-8 -*-
-# Copyright 2020 the AAS WorldWide Telescope project
+# Copyright 2021 the AAS WorldWide Telescope project
 # Licensed under the MIT License.
 
 """Common routines for tiling images anchored to the sky in a gnomonic
@@ -193,8 +193,8 @@ class StudyTiling(object):
         """
         gx = im_ix + self._img_gx0
         gy = im_iy + self._img_gy0
-        tile_ix = np.floor(gx // 256).astype(np.int)
-        tile_iy = np.floor(gy // 256).astype(np.int)
+        tile_ix = np.floor(gx // 256).astype(int)
+        tile_iy = np.floor(gy // 256).astype(int)
         return (tile_ix, tile_iy, gx % 256, gy % 256)
 
 


### PR DESCRIPTION
As we just added to `wwt_data_formats` — turns out you have to do this manually on Windows to support the (dumb) cmd shell.