### PR TITLE
tile-wwtl: add a --name argument as supported in other similar commands

### DIFF
--- a/docs/cli/tile-wwtl.rst
+++ b/docs/cli/tile-wwtl.rst
@@ -21,6 +21,7 @@ Usage
       [standard image-loading options]
       [--placeholder-thumbnail]
       [--outdir DIR]
+      [--name NAME]
       WWTL-PATH
 
 See the :ref:`cli-std-image-options` section for documentation on those options.
@@ -35,6 +36,9 @@ in a tangential (gnomonic) projection on the sky.
 
 The ``--outdir DIR`` option specifies where the output data should be written.
 If unspecified, the data root will be the current directory.
+
+The ``--name NAME`` option specifies the descriptive name for the imagery to be
+embedded inside the output WTML file. It defaults to "Toasty".
 
 If the ``--placeholder-thumbnail`` argument is given, an all-black placeholder
 thumbnail will be created. Otherwise, the thumbnail will be created by

--- a/toasty/cli.py
+++ b/toasty/cli.py
@@ -378,6 +378,12 @@ def tile_wwtl_getparser(parser):
     ImageLoader.add_arguments(parser)
 
     parser.add_argument(
+        '--name',
+        metavar = 'NAME',
+        default = 'Toasty',
+        help = 'The image name to embed in the output WTML file (default: %(default)s)',
+    )
+    parser.add_argument(
         '--placeholder-thumbnail',
         action = 'store_true',
         help = 'Do not attempt to thumbnail the input image -- saves memory for large inputs',
@@ -410,6 +416,7 @@ def tile_wwtl_impl(settings):
     else:
         builder.make_thumbnail_from_other(img)
 
+    builder.set_name(settings.name)
     builder.write_index_rel_wtml()
 
     print(f'Successfully tiled input "{settings.wwtl_path}" at level {builder.imgset.tile_levels}.')

--- a/toasty/tests/test_wwtl.py
+++ b/toasty/tests/test_wwtl.py
@@ -50,7 +50,7 @@ class TestStudy(object):
 
         # Now run it through the CLI.
 
-        for variants in ([], ['--placeholder-thumbnail']):
+        for variants in ([], ['--placeholder-thumbnail'], ['--name=Custom Name']):
             args = ['tile-wwtl']
             args += variants
             args += [


### PR DESCRIPTION
Closes #53.