### PR TITLE
add tile-allsky --projection=plate-carree-panorama

### DIFF
--- a/docs/cli/tile-allsky.rst
+++ b/docs/cli/tile-allsky.rst
@@ -63,6 +63,8 @@ mapped on to the image. Allowed types are:
   the right. This is the format in which planetary maps are typically
   represented. If you use this option when you should have used
   ``plate-carree``, or vice versa, your map come out flipped horizontally.
+- ``plate-carree-panorama`` — like the default “plate carrée” projection, but 
+  the image is interpreted as a 360 degree panoramic image
 
 .. _equirectangular: https://en.wikipedia.org/wiki/Equirectangular_projection
 

--- a/toasty/builder.py
+++ b/toasty/builder.py
@@ -127,7 +127,7 @@ class Builder(object):
         return img
 
 
-    def toast_base(self, sampler, depth, is_planet=False, **kwargs):
+    def toast_base(self, sampler, depth, is_planet=False, is_pano=False, **kwargs):
         from .toast import sample_layer
 
         self._check_no_wcs_yet()
@@ -135,6 +135,8 @@ class Builder(object):
 
         if is_planet:
             self.imgset.data_set_type = DataSetType.PLANET
+        elif is_pano:
+            self.imgset.data_set_type = DataSetType.PANORAMA
         else:
             self.imgset.data_set_type = DataSetType.SKY
 

--- a/toasty/cli.py
+++ b/toasty/cli.py
@@ -144,7 +144,7 @@ def tile_allsky_getparser(parser):
         metavar = 'PROJTYPE',
         default = 'plate-carree',
         help = 'The projection type of the input image (default: %(default)s; choices: %(choices)s)',
-        choices = ['plate-carree', 'plate-carree-galactic', 'plate-carree-ecliptic', 'plate-carree-planet'],
+        choices = ['plate-carree', 'plate-carree-galactic', 'plate-carree-ecliptic', 'plate-carree-planet', 'plate-carree-panorama'],
     )
     parser.add_argument(
         '--parallelism', '-j',
@@ -173,6 +173,7 @@ def tile_allsky_impl(settings):
     img = ImageLoader.create_from_args(settings).load_path(settings.imgpath)
     pio = PyramidIO(settings.outdir)
     is_planet = False
+    is_pano = False
 
     if settings.projection == 'plate-carree':
         from .samplers import plate_carree_sampler
@@ -187,6 +188,10 @@ def tile_allsky_impl(settings):
         from .samplers import plate_carree_planet_sampler
         sampler = plate_carree_planet_sampler(img.asarray())
         is_planet = True
+    elif settings.projection == 'plate-carree-panorama':
+        from .samplers import plate_carree_sampler
+        sampler = plate_carree_sampler(img.asarray())
+        is_pano = True
     else:
         die('the image projection type {!r} is not recognized'.format(settings.projection))
 
@@ -202,6 +207,7 @@ def tile_allsky_impl(settings):
         sampler,
         settings.depth,
         is_planet=is_planet,
+        is_pano=is_pano,
         parallel=settings.parallelism,
         cli_progress=True,
     )


### PR DESCRIPTION
This adds a panorama option to the --projection argument in tile-allsky. It is the same projection as plate-carree but writes the dataset type as panorama, saving a couple steps. I'm not sure if this is the most efficient approach but it worked in my testing.