### PR TITLE
Various FITS processing improvements

### DIFF
--- a/toasty/collection.py
+++ b/toasty/collection.py
@@ -74,11 +74,40 @@ class SimpleFitsCollection(ImageCollection):
                             break
 
                 wcs = WCS(hdu.header)
+                shape = hdu.shape
+
+                # We need to make sure the data are 2D celestial, since that's
+                # what our image code and `reproject` (if it's being used) expect.
+
+                full_wcs = None
+                keep_axes = None
+
+                if wcs.naxis != 2:
+                    if not wcs.has_celestial:
+                        raise Exception(f'cannot process input `{fits_path}`: WCS cannot be reduced to 2D celestial')
+
+                    full_wcs = wcs
+                    wcs = full_wcs.celestial
+
+                    # note: get_axis_types returns axes in FITS order, innermost first
+                    keep_axes = [t.get('coordinate_type') == 'celestial' for t in full_wcs.get_axis_types()[::-1]]
+
+                    for keep, axlen in zip(keep_axes, shape):
+                        if not keep and axlen != 1:
+                            raise Exception(f'cannot process input `{fits_path}`: found a non-celestial axis with size other than 1')
+
+                # OK, almost there. Are we loading data or just the descriptor?
 
                 if actually_load_data:
-                    result = Image.from_array(hdu.data, wcs=wcs, default_format='fits')
+                    data = hdu.data
+
+                    if full_wcs is not None:  # need to subset?
+                        data = data[tuple(slice(None) if k else 0 for k in keep_axes)]
+
+                    result = Image.from_array(data, wcs=wcs, default_format='fits')
                 else:
-                    shape = hdu.shape
+                    if full_wcs is not None:  # need to subset?
+                        shape = tuple(t[1] for t in zip(keep_axes, shape) if t[0])
 
                     if hasattr(hdu, 'dtype'):
                         mode = ImageMode.from_array_info(shape, hdu.dtype)

--- a/toasty/collection.py
+++ b/toasty/collection.py
@@ -56,9 +56,10 @@ class ImageCollection(ABC):
 
 
 class SimpleFitsCollection(ImageCollection):
-    def __init__(self, paths, hdu_index=None):
+    def __init__(self, paths, hdu_index=None, blankval=None):
         self._paths = list(paths)
         self._hdu_index = hdu_index
+        self._blankval = blankval
 
     def _load(self, actually_load_data):
         from astropy.io import fits
@@ -103,6 +104,9 @@ class SimpleFitsCollection(ImageCollection):
 
                     if full_wcs is not None:  # need to subset?
                         data = data[tuple(slice(None) if k else 0 for k in keep_axes)]
+
+                    if self._blankval is not None:
+                        data[data == self._blankval] = np.nan
 
                     result = Image.from_array(data, wcs=wcs, default_format='fits')
                 else:

--- a/toasty/image.py
+++ b/toasty/image.py
@@ -1017,7 +1017,6 @@ class Image(object):
         path_or_stream : path-like object or file-like object
             The destination into which the data should be written. If file-like,
             the stream should accept bytes.
-
         """
 
         _validate_format('format', format)
@@ -1034,9 +1033,18 @@ class Image(object):
         elif format == 'npy':
             np.save(path_or_stream, self.asarray())
         elif format == 'fits':
-            header = None if self._wcs is None else self._wcs.to_header()
-            fits.writeto(path_or_stream, self.asarray(),
-                         header=header, overwrite=True)
+            header = fits.Header() if self._wcs is None else self._wcs.to_header()
+
+            arr = self.asarray()
+            header['DATAMIN'] = np.nanmin(arr)
+            header['DATAMAX'] = np.nanmax(arr)
+
+            fits.writeto(
+                path_or_stream,
+                arr,
+                header=header,
+                overwrite=True,
+            )
 
     def make_thumbnail_bitmap(self):
         """Create a thumbnail bitmap from the image.


### PR DESCRIPTION
Save data max/min to assist the UI in setting the scale correctly, and change the multi-WCS processing to be less memory-intensive when reprojecting very large images. (Instead of reprojecting a single large image to a single large output, we reproject it to a series of medium-sized outputs.)