### PR TITLE
Hipsgen

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -18,6 +18,10 @@ Python API Reference
    :no-inheritance-diagram:
    :no-inherited-members:
 
+.. automodapi:: toasty.fits_tiler
+   :no-inheritance-diagram:
+   :no-inherited-members:
+
 .. automodapi:: toasty.image
    :no-inheritance-diagram:
    :no-inherited-members:

--- a/docs/api/toasty.collection.CollectionLoader.rst
+++ b/docs/api/toasty.collection.CollectionLoader.rst
@@ -1,0 +1,33 @@
+CollectionLoader
+================
+
+.. currentmodule:: toasty.collection
+
+.. autoclass:: CollectionLoader
+   :show-inheritance:
+
+   .. rubric:: Attributes Summary
+
+   .. autosummary::
+
+      ~CollectionLoader.blankval
+      ~CollectionLoader.hdu_index
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~CollectionLoader.add_arguments
+      ~CollectionLoader.create_from_args
+      ~CollectionLoader.load_paths
+
+   .. rubric:: Attributes Documentation
+
+   .. autoattribute:: blankval
+   .. autoattribute:: hdu_index
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: add_arguments
+   .. automethod:: create_from_args
+   .. automethod:: load_paths

--- a/docs/api/toasty.collection.ImageCollection.rst
+++ b/docs/api/toasty.collection.ImageCollection.rst
@@ -11,9 +11,11 @@ ImageCollection
    .. autosummary::
 
       ~ImageCollection.descriptions
+      ~ImageCollection.export_simple
       ~ImageCollection.images
 
    .. rubric:: Methods Documentation
 
    .. automethod:: descriptions
+   .. automethod:: export_simple
    .. automethod:: images

--- a/docs/api/toasty.collection.SimpleFitsCollection.rst
+++ b/docs/api/toasty.collection.SimpleFitsCollection.rst
@@ -11,9 +11,11 @@ SimpleFitsCollection
    .. autosummary::
 
       ~SimpleFitsCollection.descriptions
+      ~SimpleFitsCollection.export_simple
       ~SimpleFitsCollection.images
 
    .. rubric:: Methods Documentation
 
    .. automethod:: descriptions
+   .. automethod:: export_simple
    .. automethod:: images

--- a/docs/api/toasty.collection.load.rst
+++ b/docs/api/toasty.collection.load.rst
@@ -1,0 +1,6 @@
+load
+====
+
+.. currentmodule:: toasty.collection
+
+.. autofunction:: load

--- a/docs/api/toasty.fits_tiler.FitsTiler.rst
+++ b/docs/api/toasty.fits_tiler.FitsTiler.rst
@@ -1,0 +1,37 @@
+FitsTiler
+=========
+
+.. currentmodule:: toasty.fits_tiler
+
+.. autoclass:: FitsTiler
+   :show-inheritance:
+
+   .. rubric:: Attributes Summary
+
+   .. autosummary::
+
+      ~FitsTiler.builder
+      ~FitsTiler.coll
+      ~FitsTiler.force_hipsgen
+      ~FitsTiler.force_tan
+      ~FitsTiler.out_dir
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~FitsTiler.should_use_hipsgen
+      ~FitsTiler.tile
+
+   .. rubric:: Attributes Documentation
+
+   .. autoattribute:: builder
+   .. autoattribute:: coll
+   .. autoattribute:: force_hipsgen
+   .. autoattribute:: force_tan
+   .. autoattribute:: out_dir
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: should_use_hipsgen
+   .. automethod:: tile

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -19,3 +19,4 @@ CLI Reference
    cli/tile-study
    cli/tile-wwtl
    cli/transform-fx3-to-rgb
+   cli/view

--- a/docs/cli/tile-study.rst
+++ b/docs/cli/tile-study.rst
@@ -65,3 +65,4 @@ See Also
 ========
 
 - :ref:`cli-check-avm`
+- :ref:`cli-view`

--- a/docs/cli/view.rst
+++ b/docs/cli/view.rst
@@ -1,0 +1,91 @@
+.. _cli-view:
+
+=======================
+``toasty view``
+=======================
+
+The ``view`` command allows you view one or more FITS files using the `WWT
+research app`_.
+
+.. _WWT research app: https://docs.worldwidetelescope.org/research-app/latest/
+
+
+Example
+=======
+
+View a FITS file:
+
+.. code-block:: shell
+
+   toasty view myfile.fits
+
+
+Detailed Usage
+==============
+
+.. code-block:: shell
+
+   toasty view
+      [--appurl URL]
+      [--blankval NUMBER]
+      [--browser BROWSER, -b BROWSER]
+      [--hdu-index INDEX[,INDEX,...]]
+      [--parallelism COUNT, -j COUNT]
+      {FITS [FITS ...]}
+
+The ``FITS`` argument(s) give the path(s) of one or more input FITS files. These
+will be automatically tiled if necessary, then made available on a local web
+server so that the WWT viewer can access the data.
+
+The ``-b`` or ``--browser`` option specifies which web browser to use, using an
+identifier as understood by the `Python "webbrowser" module`_. Typical choices
+might be ``firefox``, ``safari``, or ``google-chrome``. If unspecified, a
+sensible default will be used.
+
+.. _Python "webbrowser" module: https://docs.python.org/3/library/webbrowser.html
+
+The ``--hdu-index`` argument, if specified, fixes the index number of the FITS
+HDU to load from the input file(s). If one value is provided, that index will be
+used for every FITS file. If a comma-separated list is provided, the index
+corresponding to each index path will be used.
+
+The ``--blankval`` argument, if specified, gives a data value to be treated as
+undefined data when processing the FITS data.
+
+The ``--parallelism COUNT`` (or ``-j COUNT``) argument specifies the level of
+parallism to use in the tiling and downsampling process. On operating systems
+that support parallel processing, the default is to use all CPUs. To disable
+parallel processing, explicitly specify a factor of 1.
+
+The ``--appurl`` option can be used to override the base URL for the preview app
+that will be used. This can be helpful when developing new features in one of
+these apps.
+
+
+Details
+=======
+
+This command provides similar functionality as the ``wwtdatatool preview``
+command `provided by the wwt_data_formats package`_, but automatically tiles its
+inputs and generates the needed ``index_rel.wtml`` file.
+
+.. _provided by the wwt_data_formats package: https://wwt-data-formats.readthedocs.io/en/latest/cli/preview.html
+
+If tiling is required and the tile output directory already exists, the tool
+assumes that the image was already successfully tiled, and skips straight to
+launching the viewer without rerunning the tiling process.
+
+The FITS data will be tiled either onto a common tangential projection, or into
+a HiPS format using `hipsgen`_, depending on the angular size subtended by the
+data. If any of the FITS image corners are separated by more than 20 degrees and
+Java is available, `hipsgen`_ will be used. Otherwise, Toasty's internal
+processing will be used, reprojecting the input data into a tangential
+(gnomonic) projection if necessary.
+
+.. _hipsgen: https://aladin.u-strasbg.fr/hips/HipsIn10Steps.gml
+
+
+See Also
+========
+
+- :ref:`cli-tile-study`

--- a/toasty/__init__.py
+++ b/toasty/__init__.py
@@ -5,24 +5,37 @@
 from __future__ import absolute_import, division, print_function
 
 
-def tile_fits(fits, out_dir=None, cli_progress=False, **kwargs):
+def tile_fits(fits, out_dir=None, hdu_index=None, override=False, cli_progress=False, force_hipsgen=False,
+              force_tan=False, **kwargs):
     """
-    Process a file or a list of FITS files into a tile pyramid with
-    a common tangential projection.
+    Process a file or a list of FITS files into a tile pyramid using either a common tangential projection or HiPSgen.
 
     Parameters
     ----------
     fits : str or list of str
         A single path or a list of paths to FITS files to be processed.
-    out_dir : optional str
-        A path to the output directory where all the tiled fits will be
-        located. If not set, the output directory will be at the location of
-        the first FITS file.
-    cli_progress : optional boolean, defaults False
-        If true, a progress bar will be printed to the terminal using tqdm.
+    out_dir : optional str, defaults to None
+        A path to the output directory where all the tiled fits will be located. If not set, the output directory will
+        be at the location of the first FITS file.
+    hdu_index : optional int or list of int, defaults to None
+        Use this parameter to specify which HDU to tile. If the `fits` input is a list of FITS, you can specify the
+        hdu_index of each FITS by using a list of integers like this: [0, 2, 1]. If hdu_index is not set, toasty will
+        use the first HDU with tilable content in each FITS.
+    override : optional boolean, defaults to False
+        If there is already a tiled FITS in `out_dir`, the tiling process is skipped and the content in `out_dir` is
+        served. To override the content in `out_dir`, set `override` to True.
+    cli_progress : optional boolean, defaults to False
+        If true, progress messages will be printed as the FITS files are being processed.
+    force_hipsgen : optional boolean, defaults to False
+        Force usage of HiPSgen tiling over tangential projection. If this and `force_tan` is set to False, this method
+        will figure out when to use the different projections. Tangential projection for smaller angular areas and
+        HiPSgen larger regions of the sky.
+    force_tan : optional boolean, defaults to False
+        Force usage of tangential projection tiling over HiPSgen. If this and `force_hipsgen` is set to False, this
+        method will figure out when to use the different projections. Tangential projection for smaller angular areas
+        and HiPSgen larger regions of the sky.
     kwargs
-        Settings for the `toasty` tiling process. Common
-        settings include 'hdu_index' and 'blankval'.
+        Settings for the `toasty` tiling process. For example, 'blankval'.
 
     Returns
     -------
@@ -32,38 +45,43 @@ def tile_fits(fits, out_dir=None, cli_progress=False, **kwargs):
         State for the imagery data set that's been assembled.
     """
 
-    from toasty import builder, collection, pyramid, multi_tan, multi_wcs
-    import reproject
+    # Importing here to keep toasty namespace clean
+    from toasty import fits_tiler, pyramid, builder
+    import os
 
     if isinstance(fits, str):
         fits = [fits]
 
     fits = list(fits)
 
+    tiler = fits_tiler.FitsTiler()
+
+    use_hipsgen = force_hipsgen or (tiler.fits_covers_large_area(fits, hdu_index) and
+                                    tiler.is_java_installed() and not force_tan)
+
     if out_dir is None:
         first_file_name = fits[0].split('.gz')[0]
         out_dir = first_file_name[:first_file_name.rfind('.')] + '_tiled'
+        if use_hipsgen:
+            out_dir += '_HiPS'
 
-    pio = pyramid.PyramidIO(out_dir, default_format='fits')
-    bld = builder.Builder(pio)
-    coll = collection.SimpleFitsCollection(fits, **kwargs)
-    if cli_progress:
-        print('Tiling base layer (Step 1 of 2)')
-    if coll._is_multi_tan():
-        tile_processor = multi_tan.MultiTanProcessor(coll)
-        tile_processor.compute_global_pixelization(bld)
-        tile_processor.tile(pio, cli_progress=cli_progress, **kwargs)
-    else:
-        tile_processor = multi_wcs.MultiWcsProcessor(coll)
-        tile_processor.compute_global_pixelization(bld)
-        tile_processor.tile(pio, reproject.reproject_interp, cli_progress=cli_progress, **kwargs)
+    if os.path.isdir(out_dir):
+        if cli_progress:
+            print('Folder already exist')
+        if override:
+            import shutil
+            shutil.rmtree(out_dir)
+        else:
+            if cli_progress:
+                print('Using existing tiles')
+            pio = pyramid.PyramidIO(out_dir, default_format='fits')
+            bld = builder.Builder(pio)
+            bld.set_name(out_dir.split('/')[-1])
+            if os.path.exists('{0}/properties'.format(out_dir)):
+                bld = tiler.copy_hips_properties_to_builder(bld, out_dir)
+            return out_dir, bld
 
-    if cli_progress:
-        print('Downsampling (Step 2 of 2)')
-    bld.cascade(cli_progress=cli_progress, **kwargs)
+    if use_hipsgen:
+        return tiler.tile_hips(fits, out_dir, hdu_index, cli_progress)
 
-    # Using the file name of the first FITS file as the image collection name
-    bld.set_name(out_dir.split('/')[-1])
-    bld.write_index_rel_wtml()
-
-    return out_dir, bld
+    return tiler.tile_tan(fits, out_dir, hdu_index, cli_progress, **kwargs)

--- a/toasty/__init__.py
+++ b/toasty/__init__.py
@@ -18,24 +18,24 @@ def tile_fits(fits, out_dir=None, hdu_index=None, override=False, cli_progress=F
         A path to the output directory where all the tiled fits will be located. If not set, the output directory will
         be at the location of the first FITS file.
     hdu_index : optional int or list of int, defaults to None
-        Use this parameter to specify which HDU to tile. If the `fits` input is a list of FITS, you can specify the
+        Use this parameter to specify which HDU to tile. If the *fits* input is a list of FITS, you can specify the
         hdu_index of each FITS by using a list of integers like this: [0, 2, 1]. If hdu_index is not set, toasty will
         use the first HDU with tilable content in each FITS.
     override : optional boolean, defaults to False
-        If there is already a tiled FITS in `out_dir`, the tiling process is skipped and the content in `out_dir` is
-        served. To override the content in `out_dir`, set `override` to True.
+        If there is already a tiled FITS in *out_dir*, the tiling process is skipped and the content in *out_dir* is
+        served. To override the content in *out_dir*, set *override* to True.
     cli_progress : optional boolean, defaults to False
         If true, progress messages will be printed as the FITS files are being processed.
     force_hipsgen : optional boolean, defaults to False
-        Force usage of HiPSgen tiling over tangential projection. If this and `force_tan` is set to False, this method
+        Force usage of HiPSgen tiling over tangential projection. If this and *force_tan* are set to False, this method
         will figure out when to use the different projections. Tangential projection for smaller angular areas and
         HiPSgen larger regions of the sky.
     force_tan : optional boolean, defaults to False
-        Force usage of tangential projection tiling over HiPSgen. If this and `force_hipsgen` is set to False, this
+        Force usage of tangential projection tiling over HiPSgen. If this and *force_hipsgen* are set to False, this
         method will figure out when to use the different projections. Tangential projection for smaller angular areas
         and HiPSgen larger regions of the sky.
     kwargs
-        Settings for the `toasty` tiling process. For example, 'blankval'.
+        Settings for the tiling process. For example, ``blankval``.
 
     Returns
     -------

--- a/toasty/__init__.py
+++ b/toasty/__init__.py
@@ -5,8 +5,16 @@
 from __future__ import absolute_import, division, print_function
 
 
-def tile_fits(fits, out_dir=None, hdu_index=None, override=False, cli_progress=False, force_hipsgen=False,
-              force_tan=False, **kwargs):
+def tile_fits(
+    fits,
+    out_dir=None,
+    hdu_index=None,
+    override=False,
+    cli_progress=False,
+    force_hipsgen=False,
+    force_tan=False,
+    **kwargs
+):
     """
     Process a file or a list of FITS files into a tile pyramid using either a common tangential projection or HiPSgen.
 
@@ -56,28 +64,32 @@ def tile_fits(fits, out_dir=None, hdu_index=None, override=False, cli_progress=F
 
     tiler = fits_tiler.FitsTiler()
 
-    use_hipsgen = force_hipsgen or (tiler.fits_covers_large_area(fits, hdu_index) and
-                                    tiler.is_java_installed() and not force_tan)
+    use_hipsgen = force_hipsgen or (
+        tiler.fits_covers_large_area(fits, hdu_index)
+        and tiler.is_java_installed()
+        and not force_tan
+    )
 
     if out_dir is None:
-        first_file_name = fits[0].split('.gz')[0]
-        out_dir = first_file_name[:first_file_name.rfind('.')] + '_tiled'
+        first_file_name = fits[0].split(".gz")[0]
+        out_dir = first_file_name[: first_file_name.rfind(".")] + "_tiled"
         if use_hipsgen:
-            out_dir += '_HiPS'
+            out_dir += "_HiPS"
 
     if os.path.isdir(out_dir):
         if cli_progress:
-            print('Folder already exist')
+            print("Folder already exist")
         if override:
             import shutil
+
             shutil.rmtree(out_dir)
         else:
             if cli_progress:
-                print('Using existing tiles')
-            pio = pyramid.PyramidIO(out_dir, default_format='fits')
+                print("Using existing tiles")
+            pio = pyramid.PyramidIO(out_dir, default_format="fits")
             bld = builder.Builder(pio)
-            bld.set_name(out_dir.split('/')[-1])
-            if os.path.exists('{0}/properties'.format(out_dir)):
+            bld.set_name(out_dir.split("/")[-1])
+            if os.path.exists("{0}/properties".format(out_dir)):
                 bld = tiler.copy_hips_properties_to_builder(bld, out_dir)
             return out_dir, bld
 

--- a/toasty/cli.py
+++ b/toasty/cli.py
@@ -8,11 +8,11 @@
 
 from __future__ import absolute_import, division, print_function
 
-__all__ = '''
+__all__ = """
 die
 entrypoint
 warn
-'''.split()
+""".split()
 
 import argparse
 import os.path
@@ -24,40 +24,45 @@ from wwt_data_formats.cli import EnsureGlobsExpandedAction
 
 # General CLI utilities
 
+
 def die(msg):
-    print('error:', msg, file=sys.stderr)
+    print("error:", msg, file=sys.stderr)
     sys.exit(1)
 
+
 def warn(msg):
-    print('warning:', msg, file=sys.stderr)
+    print("warning:", msg, file=sys.stderr)
 
 
 # "cascade" subcommand
 
+
 def cascade_getparser(parser):
     parser.add_argument(
-        '--parallelism', '-j',
-        metavar = 'COUNT',
-        type = int,
-        help = 'The parallelization level (default: use all CPUs; specify `1` to force serial processing)',
+        "--parallelism",
+        "-j",
+        metavar="COUNT",
+        type=int,
+        help="The parallelization level (default: use all CPUs; specify `1` to force serial processing)",
     )
     parser.add_argument(
-        '--format', '-f',
-        metavar = 'FORMAT',
-        default = None,
-        choices = ['png', 'jpg', 'npy', 'fits'],
-        help = 'The format of data files to cascade. If not specified, this will be guessed.',
+        "--format",
+        "-f",
+        metavar="FORMAT",
+        default=None,
+        choices=["png", "jpg", "npy", "fits"],
+        help="The format of data files to cascade. If not specified, this will be guessed.",
     )
     parser.add_argument(
-        '--start',
-        metavar = 'DEPTH',
-        type = int,
-        help = 'The depth of the TOAST layer to start the cascade',
+        "--start",
+        metavar="DEPTH",
+        type=int,
+        help="The depth of the TOAST layer to start the cascade",
     )
     parser.add_argument(
-        'pyramid_dir',
-        metavar = 'DIR',
-        help = 'The directory containing the tile pyramid to cascade',
+        "pyramid_dir",
+        metavar="DIR",
+        help="The directory containing the tile pyramid to cascade",
     )
 
 
@@ -70,35 +75,33 @@ def cascade_impl(settings):
 
     start = settings.start
     if start is None:
-        die('currently, you must specify the start layer with the --start option')
+        die("currently, you must specify the start layer with the --start option")
 
     cascade_images(
-        pio,
-        start,
-        averaging_merger,
-        parallel=settings.parallelism,
-        cli_progress=True
+        pio, start, averaging_merger, parallel=settings.parallelism, cli_progress=True
     )
 
 
 # "check-avm" subcommand
 
+
 def check_avm_getparser(parser):
     parser.add_argument(
-        '--print', '-p',
-        dest = 'print_avm',
-        action = 'store_true',
-        help = 'Print the AVM data if present',
+        "--print",
+        "-p",
+        dest="print_avm",
+        action="store_true",
+        help="Print the AVM data if present",
     )
     parser.add_argument(
-        '--exitcode',
-        action = 'store_true',
-        help = 'Exit with code 1 if no AVM tags are present',
+        "--exitcode",
+        action="store_true",
+        help="Exit with code 1 if no AVM tags are present",
     )
     parser.add_argument(
-        'image',
-        metavar = 'PATH',
-        help = 'An image to check for AVM tags',
+        "image",
+        metavar="PATH",
+        help="An image to check for AVM tags",
     )
 
 
@@ -112,45 +115,49 @@ def check_avm_impl(settings):
             exceptions.AVMEmptyValueError,
         )
     except ImportError:
-        die('cannot check AVM tags: you must install the `pyavm` package')
+        die("cannot check AVM tags: you must install the `pyavm` package")
 
     try:
         # PyAVM can issue a lot of warnings that aren't helpful to the user.
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
+            warnings.simplefilter("ignore")
             avm = AVM.from_image(settings.image)
     except exceptions.NoXMPPacketFound:
-        print(f'{settings.image}: no AVM tags')
+        print(f"{settings.image}: no AVM tags")
         sys.exit(1 if settings.exitcode else 0)
     except SYNTAX_EXCEPTIONS as e:
-        print(f'{settings.image}: AVM data are present but malformed: {e} ({e.__class__.__name__})')
+        print(
+            f"{settings.image}: AVM data are present but malformed: {e} ({e.__class__.__name__})"
+        )
         sys.exit(1)
     except IOError as e:
-        die(f'error probing AVM tags of `{settings.image}`: {e}')
+        die(f"error probing AVM tags of `{settings.image}`: {e}")
 
     if settings.print_avm:
-        print(f'{settings.image}: AVM tags are present')
+        print(f"{settings.image}: AVM tags are present")
         print()
         print(avm)
     else:
-        print(f'{settings.image}: AVM tags are present (use `--print` to display them)')
+        print(f"{settings.image}: AVM tags are present (use `--print` to display them)")
 
 
 # "make_thumbnail" subcommand
 
+
 def make_thumbnail_getparser(parser):
     from .image import ImageLoader
+
     ImageLoader.add_arguments(parser)
 
     parser.add_argument(
-        'imgpath',
-        metavar = 'IN-PATH',
-        help = 'The image file to be thumbnailed',
+        "imgpath",
+        metavar="IN-PATH",
+        help="The image file to be thumbnailed",
     )
     parser.add_argument(
-        'outpath',
-        metavar = 'OUT-PATH',
-        help = 'The location of the new thumbnail file',
+        "outpath",
+        metavar="OUT-PATH",
+        help="The location of the new thumbnail file",
     )
 
 
@@ -158,14 +165,18 @@ def make_thumbnail_impl(settings):
     from .image import ImageLoader
 
     olp = settings.outpath.lower()
-    if not (olp.endswith('.jpg') or olp.endswith('.jpeg')):
-        warn('saving output in JPEG format even though filename is "{}"'.format(settings.outpath))
+    if not (olp.endswith(".jpg") or olp.endswith(".jpeg")):
+        warn(
+            'saving output in JPEG format even though filename is "{}"'.format(
+                settings.outpath
+            )
+        )
 
     img = ImageLoader.create_from_args(settings).load_path(settings.imgpath)
     thumb = img.make_thumbnail_bitmap()
 
-    with open(settings.outpath, 'wb') as f:
-        thumb.save(f, format='JPEG')
+    with open(settings.outpath, "wb") as f:
+        thumb.save(f, format="JPEG")
 
 
 # "pipeline" subcommands
@@ -175,50 +186,59 @@ from .pipeline.cli import pipeline_getparser, pipeline_impl
 
 # "tile_allsky" subcommand
 
+
 def tile_allsky_getparser(parser):
     from .image import ImageLoader
+
     ImageLoader.add_arguments(parser)
 
     parser.add_argument(
-        '--name',
-        metavar = 'NAME',
-        default = 'Toasty',
-        help = 'The image name to embed in the output WTML file (default: %(default)s)',
+        "--name",
+        metavar="NAME",
+        default="Toasty",
+        help="The image name to embed in the output WTML file (default: %(default)s)",
     )
     parser.add_argument(
-        '--outdir',
-        metavar = 'PATH',
-        default = '.',
-        help = 'The root directory of the output tile pyramid (default: %(default)s)',
+        "--outdir",
+        metavar="PATH",
+        default=".",
+        help="The root directory of the output tile pyramid (default: %(default)s)",
     )
     parser.add_argument(
-        '--placeholder-thumbnail',
-        action = 'store_true',
-        help = 'Do not attempt to thumbnail the input image -- saves memory for large inputs',
+        "--placeholder-thumbnail",
+        action="store_true",
+        help="Do not attempt to thumbnail the input image -- saves memory for large inputs",
     )
     parser.add_argument(
-        '--projection',
-        metavar = 'PROJTYPE',
-        default = 'plate-carree',
-        help = 'The projection type of the input image (default: %(default)s; choices: %(choices)s)',
-        choices = ['plate-carree', 'plate-carree-galactic', 'plate-carree-ecliptic', 'plate-carree-planet', 'plate-carree-panorama'],
+        "--projection",
+        metavar="PROJTYPE",
+        default="plate-carree",
+        help="The projection type of the input image (default: %(default)s; choices: %(choices)s)",
+        choices=[
+            "plate-carree",
+            "plate-carree-galactic",
+            "plate-carree-ecliptic",
+            "plate-carree-planet",
+            "plate-carree-panorama",
+        ],
     )
     parser.add_argument(
-        '--parallelism', '-j',
-        metavar = 'COUNT',
-        type = int,
-        help = 'The parallelization level (default: use all CPUs if OS supports; specify `1` to force serial processing)',
+        "--parallelism",
+        "-j",
+        metavar="COUNT",
+        type=int,
+        help="The parallelization level (default: use all CPUs if OS supports; specify `1` to force serial processing)",
     )
     parser.add_argument(
-        'imgpath',
-        metavar = 'PATH',
-        help = 'The image file to be tiled',
+        "imgpath",
+        metavar="PATH",
+        help="The image file to be tiled",
     )
     parser.add_argument(
-        'depth',
-        metavar = 'DEPTH',
-        type = int,
-        help = 'The depth of the TOAST layer to sample',
+        "depth",
+        metavar="DEPTH",
+        type=int,
+        help="The depth of the TOAST layer to sample",
     )
 
 
@@ -232,25 +252,34 @@ def tile_allsky_impl(settings):
     is_planet = False
     is_pano = False
 
-    if settings.projection == 'plate-carree':
+    if settings.projection == "plate-carree":
         from .samplers import plate_carree_sampler
+
         sampler = plate_carree_sampler(img.asarray())
-    elif settings.projection == 'plate-carree-galactic':
+    elif settings.projection == "plate-carree-galactic":
         from .samplers import plate_carree_galactic_sampler
+
         sampler = plate_carree_galactic_sampler(img.asarray())
-    elif settings.projection == 'plate-carree-ecliptic':
+    elif settings.projection == "plate-carree-ecliptic":
         from .samplers import plate_carree_ecliptic_sampler
+
         sampler = plate_carree_ecliptic_sampler(img.asarray())
-    elif settings.projection == 'plate-carree-planet':
+    elif settings.projection == "plate-carree-planet":
         from .samplers import plate_carree_planet_sampler
+
         sampler = plate_carree_planet_sampler(img.asarray())
         is_planet = True
-    elif settings.projection == 'plate-carree-panorama':
+    elif settings.projection == "plate-carree-panorama":
         from .samplers import plate_carree_sampler
+
         sampler = plate_carree_sampler(img.asarray())
         is_pano = True
     else:
-        die('the image projection type {!r} is not recognized'.format(settings.projection))
+        die(
+            "the image projection type {!r} is not recognized".format(
+                settings.projection
+            )
+        )
 
     builder = Builder(pio)
 
@@ -271,31 +300,34 @@ def tile_allsky_impl(settings):
     builder.set_name(settings.name)
     builder.write_index_rel_wtml()
 
-    print(f'Successfully tiled input "{settings.imgpath}" at level {builder.imgset.tile_levels}.')
-    print('To create parent tiles, consider running:')
+    print(
+        f'Successfully tiled input "{settings.imgpath}" at level {builder.imgset.tile_levels}.'
+    )
+    print("To create parent tiles, consider running:")
     print()
-    print(f'   toasty cascade --start {builder.imgset.tile_levels} {settings.outdir}')
+    print(f"   toasty cascade --start {builder.imgset.tile_levels} {settings.outdir}")
 
 
 # "tile_healpix" subcommand
 
+
 def tile_healpix_getparser(parser):
     parser.add_argument(
-        '--outdir',
-        metavar = 'PATH',
-        default = '.',
-        help = 'The root directory of the output tile pyramid',
+        "--outdir",
+        metavar="PATH",
+        default=".",
+        help="The root directory of the output tile pyramid",
     )
     parser.add_argument(
-        'fitspath',
-        metavar = 'PATH',
-        help = 'The HEALPix FITS file to be tiled',
+        "fitspath",
+        metavar="PATH",
+        help="The HEALPix FITS file to be tiled",
     )
     parser.add_argument(
-        'depth',
-        metavar = 'DEPTH',
-        type = int,
-        help = 'The depth of the TOAST layer to sample',
+        "depth",
+        metavar="DEPTH",
+        type=int,
+        help="The depth of the TOAST layer to sample",
     )
 
 
@@ -305,47 +337,52 @@ def tile_healpix_impl(settings):
     from .pyramid import PyramidIO
     from .samplers import healpix_fits_file_sampler
 
-    pio = PyramidIO(settings.outdir, default_format='npy')
+    pio = PyramidIO(settings.outdir, default_format="npy")
     sampler = healpix_fits_file_sampler(settings.fitspath)
     builder = Builder(pio)
     builder.toast_base(sampler, settings.depth)
     builder.write_index_rel_wtml()
 
-    print(f'Successfully tiled input "{settings.fitspath}" at level {builder.imgset.tile_levels}.')
-    print('To create parent tiles, consider running:')
+    print(
+        f'Successfully tiled input "{settings.fitspath}" at level {builder.imgset.tile_levels}.'
+    )
+    print("To create parent tiles, consider running:")
     print()
-    print(f'   toasty cascade --start {builder.imgset.tile_levels} {settings.outdir}')
+    print(f"   toasty cascade --start {builder.imgset.tile_levels} {settings.outdir}")
 
 
 # "tile_multi_tan" subcommand
 
+
 def tile_multi_tan_getparser(parser):
     parser.add_argument(
-        '--parallelism', '-j',
-        metavar = 'COUNT',
-        type = int,
-        help = 'The parallelization level (default: use all CPUs; specify `1` to force serial processing)',
+        "--parallelism",
+        "-j",
+        metavar="COUNT",
+        type=int,
+        help="The parallelization level (default: use all CPUs; specify `1` to force serial processing)",
     )
     parser.add_argument(
-        '--hdu-index',
-        metavar = 'INDEX',
-        type = int,
-        default = 0,
-        help = 'Which HDU to load in each input FITS file',
+        "--hdu-index",
+        metavar="INDEX",
+        type=int,
+        default=0,
+        help="Which HDU to load in each input FITS file",
     )
     parser.add_argument(
-        '--outdir',
-        metavar = 'PATH',
-        default = '.',
-        help = 'The root directory of the output tile pyramid',
+        "--outdir",
+        metavar="PATH",
+        default=".",
+        help="The root directory of the output tile pyramid",
     )
     parser.add_argument(
-        'paths',
-        metavar = 'PATHS',
-        action = EnsureGlobsExpandedAction,
-        nargs = '+',
-        help = 'The FITS files with image data',
+        "paths",
+        metavar="PATHS",
+        action=EnsureGlobsExpandedAction,
+        nargs="+",
+        help="The FITS files with image data",
     )
+
 
 def tile_multi_tan_impl(settings):
     from .builder import Builder
@@ -354,7 +391,7 @@ def tile_multi_tan_impl(settings):
     from .multi_tan import MultiTanProcessor
     from .pyramid import PyramidIO
 
-    pio = PyramidIO(settings.outdir, default_format='fits')
+    pio = PyramidIO(settings.outdir, default_format="fits")
     builder = Builder(pio)
 
     collection = SimpleFitsCollection(settings.paths, hdu_index=settings.hdu_index)
@@ -368,44 +405,46 @@ def tile_multi_tan_impl(settings):
     )
     builder.write_index_rel_wtml()
 
-    print(f'Successfully tiled inputs at level {builder.imgset.tile_levels}.')
-    print('To create parent tiles, consider running:')
+    print(f"Successfully tiled inputs at level {builder.imgset.tile_levels}.")
+    print("To create parent tiles, consider running:")
     print()
-    print(f'   toasty cascade --start {builder.imgset.tile_levels} {settings.outdir}')
+    print(f"   toasty cascade --start {builder.imgset.tile_levels} {settings.outdir}")
 
 
 # "tile_study" subcommand
 
+
 def tile_study_getparser(parser):
     from .image import ImageLoader
+
     ImageLoader.add_arguments(parser)
 
     parser.add_argument(
-        '--name',
-        metavar = 'NAME',
-        default = 'Toasty',
-        help = 'The image name to embed in the output WTML file (default: %(default)s)',
+        "--name",
+        metavar="NAME",
+        default="Toasty",
+        help="The image name to embed in the output WTML file (default: %(default)s)",
     )
     parser.add_argument(
-        '--avm',
-        action = 'store_true',
-        help = 'Expect the input image to have AVM positioning tags',
+        "--avm",
+        action="store_true",
+        help="Expect the input image to have AVM positioning tags",
     )
     parser.add_argument(
-        '--placeholder-thumbnail',
-        action = 'store_true',
-        help = 'Do not attempt to thumbnail the input image -- saves memory for large inputs',
+        "--placeholder-thumbnail",
+        action="store_true",
+        help="Do not attempt to thumbnail the input image -- saves memory for large inputs",
     )
     parser.add_argument(
-        '--outdir',
-        metavar = 'PATH',
-        default = '.',
-        help = 'The root directory of the output tile pyramid',
+        "--outdir",
+        metavar="PATH",
+        default=".",
+        help="The root directory of the output tile pyramid",
     )
     parser.add_argument(
-        'imgpath',
-        metavar = 'PATH',
-        help = 'The study image file to be tiled',
+        "imgpath",
+        metavar="PATH",
+        help="The study image file to be tiled",
     )
 
 
@@ -431,14 +470,17 @@ def tile_study_impl(settings):
         try:
             from pyavm import AVM
         except ImportError:
-            die('cannot use AVM data: you must install the `pyavm` package')
+            die("cannot use AVM data: you must install the `pyavm` package")
 
         try:
             with warnings.catch_warnings():
-                warnings.simplefilter('ignore')
+                warnings.simplefilter("ignore")
                 avm = AVM.from_image(settings.imgpath)
         except Exception:
-            print(f'error: failed to read AVM tags of input `{settings.imgpath}`', file=sys.stderr)
+            print(
+                f"error: failed to read AVM tags of input `{settings.imgpath}`",
+                file=sys.stderr,
+            )
             raise
 
         builder.apply_avm_info(avm, img.width, img.height)
@@ -463,39 +505,43 @@ def tile_study_impl(settings):
     builder.set_name(settings.name)
     builder.write_index_rel_wtml()
 
-    print(f'Successfully tiled input "{settings.imgpath}" at level {builder.imgset.tile_levels}.')
-    print('To create parent tiles, consider running:')
+    print(
+        f'Successfully tiled input "{settings.imgpath}" at level {builder.imgset.tile_levels}.'
+    )
+    print("To create parent tiles, consider running:")
     print()
-    print(f'   toasty cascade --start {builder.imgset.tile_levels} {settings.outdir}')
+    print(f"   toasty cascade --start {builder.imgset.tile_levels} {settings.outdir}")
 
 
 # "tile_wwtl" subcommand
 
+
 def tile_wwtl_getparser(parser):
     from .image import ImageLoader
+
     ImageLoader.add_arguments(parser)
 
     parser.add_argument(
-        '--name',
-        metavar = 'NAME',
-        default = 'Toasty',
-        help = 'The image name to embed in the output WTML file (default: %(default)s)',
+        "--name",
+        metavar="NAME",
+        default="Toasty",
+        help="The image name to embed in the output WTML file (default: %(default)s)",
     )
     parser.add_argument(
-        '--placeholder-thumbnail',
-        action = 'store_true',
-        help = 'Do not attempt to thumbnail the input image -- saves memory for large inputs',
+        "--placeholder-thumbnail",
+        action="store_true",
+        help="Do not attempt to thumbnail the input image -- saves memory for large inputs",
     )
     parser.add_argument(
-        '--outdir',
-        metavar = 'PATH',
-        default = '.',
-        help = 'The root directory of the output tile pyramid',
+        "--outdir",
+        metavar="PATH",
+        default=".",
+        help="The root directory of the output tile pyramid",
     )
     parser.add_argument(
-        'wwtl_path',
-        metavar = 'WWTL-PATH',
-        help = 'The WWTL layer file to be processed',
+        "wwtl_path",
+        metavar="WWTL-PATH",
+        help="The WWTL layer file to be processed",
     )
 
 
@@ -517,70 +563,76 @@ def tile_wwtl_impl(settings):
     builder.set_name(settings.name)
     builder.write_index_rel_wtml()
 
-    print(f'Successfully tiled input "{settings.wwtl_path}" at level {builder.imgset.tile_levels}.')
-    print('To create parent tiles, consider running:')
+    print(
+        f'Successfully tiled input "{settings.wwtl_path}" at level {builder.imgset.tile_levels}.'
+    )
+    print("To create parent tiles, consider running:")
     print()
-    print(f'   toasty cascade --start {builder.imgset.tile_levels} {settings.outdir}')
+    print(f"   toasty cascade --start {builder.imgset.tile_levels} {settings.outdir}")
 
 
 # "transform" subcommand
 
+
 def transform_getparser(parser):
-    subparsers = parser.add_subparsers(dest='transform_command')
+    subparsers = parser.add_subparsers(dest="transform_command")
 
-    parser = subparsers.add_parser('fx3-to-rgb')
+    parser = subparsers.add_parser("fx3-to-rgb")
     parser.add_argument(
-        '--parallelism', '-j',
-        metavar = 'COUNT',
-        type = int,
-        help = 'The parallelization level (default: use all CPUs; specify `1` to force serial processing)',
+        "--parallelism",
+        "-j",
+        metavar="COUNT",
+        type=int,
+        help="The parallelization level (default: use all CPUs; specify `1` to force serial processing)",
     )
     parser.add_argument(
-        '--start',
-        metavar = 'DEPTH',
-        type = int,
-        help = 'How deep in the tile pyramid to proceed wth the transformation',
+        "--start",
+        metavar="DEPTH",
+        type=int,
+        help="How deep in the tile pyramid to proceed wth the transformation",
     )
     parser.add_argument(
-        '--clip', '-c',
-        metavar = 'NUMBER',
-        type = float,
-        default = 1.0,
-        help = 'The level at which to start flipping the floating-point data',
+        "--clip",
+        "-c",
+        metavar="NUMBER",
+        type=float,
+        default=1.0,
+        help="The level at which to start flipping the floating-point data",
     )
     parser.add_argument(
-        '--outdir',
-        metavar = 'PATH',
-        help = 'Output transformed data into this directory, instead of operating in-place',
+        "--outdir",
+        metavar="PATH",
+        help="Output transformed data into this directory, instead of operating in-place",
     )
     parser.add_argument(
-        'pyramid_dir',
-        metavar = 'DIR',
-        help = 'The directory containing the tile pyramid to transform',
+        "pyramid_dir",
+        metavar="DIR",
+        help="The directory containing the tile pyramid to transform",
     )
 
-    parser = subparsers.add_parser('u8-to-rgb')
+    parser = subparsers.add_parser("u8-to-rgb")
     parser.add_argument(
-        '--parallelism', '-j',
-        metavar = 'COUNT',
-        type = int,
-        help = 'The parallelization level (default: use all CPUs; specify `1` to force serial processing)',
+        "--parallelism",
+        "-j",
+        metavar="COUNT",
+        type=int,
+        help="The parallelization level (default: use all CPUs; specify `1` to force serial processing)",
     )
     parser.add_argument(
-        '--start',
-        metavar = 'DEPTH',
-        type = int,
-        help = 'How deep in the tile pyramid to proceed wth the transformation',
+        "--start",
+        metavar="DEPTH",
+        type=int,
+        help="How deep in the tile pyramid to proceed wth the transformation",
     )
     parser.add_argument(
-        '--outdir',
-        metavar = 'PATH',
-        help = 'Output transformed data into this directory, instead of operating in-place',
+        "--outdir",
+        metavar="PATH",
+        help="Output transformed data into this directory, instead of operating in-place",
     )
     parser.add_argument(
-        'pyramid_dir',
-        metavar = 'DIR',
-        help = 'The directory containing the tile pyramid to transform',
+        "pyramid_dir",
+        metavar="DIR",
+        help="The directory containing the tile pyramid to transform",
     )
 
 
@@ -591,7 +643,7 @@ def transform_impl(settings):
         print('Run the "transform" command with `--help` for help on its subcommands')
         return
 
-    if settings.transform_command == 'fx3-to-rgb':
+    if settings.transform_command == "fx3-to-rgb":
         pio = PyramidIO(settings.pyramid_dir)
         pio_out = None
 
@@ -599,14 +651,16 @@ def transform_impl(settings):
             pio_out = PyramidIO(settings.outdir)
 
         from .transform import f16x3_to_rgb
+
         f16x3_to_rgb(
-            pio, settings.start,
-            clip = settings.clip,
-            pio_out = pio_out,
-            parallel = settings.parallelism,
-            cli_progress = True,
+            pio,
+            settings.start,
+            clip=settings.clip,
+            pio_out=pio_out,
+            parallel=settings.parallelism,
+            cli_progress=True,
         )
-    elif settings.transform_command == 'u8-to-rgb':
+    elif settings.transform_command == "u8-to-rgb":
         pio = PyramidIO(settings.pyramid_dir)
         pio_out = None
 
@@ -614,17 +668,20 @@ def transform_impl(settings):
             pio_out = PyramidIO(settings.outdir)
 
         from .transform import u8_to_rgb
+
         u8_to_rgb(
-            pio, settings.start,
-            pio_out = pio_out,
-            parallel = settings.parallelism,
-            cli_progress = True,
+            pio,
+            settings.start,
+            pio_out=pio_out,
+            parallel=settings.parallelism,
+            cli_progress=True,
         )
     else:
         die('unrecognized "transform" subcommand ' + settings.transform_command)
 
 
 # The CLI driver:
+
 
 def entrypoint(args=None):
     """The entrypoint for the \"toasty\" command-line interface.
@@ -644,8 +701,8 @@ def entrypoint(args=None):
     commands = set()
 
     for py_name, value in globals().items():
-        if py_name.endswith('_getparser'):
-            cmd_name = py_name[:-10].replace('_', '-')
+        if py_name.endswith("_getparser"):
+            cmd_name = py_name[:-10].replace("_", "-")
             subparser = subparsers.add_parser(cmd_name)
             value(subparser)
             commands.add(cmd_name)
@@ -655,15 +712,15 @@ def entrypoint(args=None):
     settings = parser.parse_args(args)
 
     if settings.subcommand is None:
-        print('Run me with --help for help. Allowed subcommands are:')
+        print("Run me with --help for help. Allowed subcommands are:")
         print()
         for cmd in sorted(commands):
-            print('   ', cmd)
+            print("   ", cmd)
         return
 
-    py_name = settings.subcommand.replace('-', '_')
+    py_name = settings.subcommand.replace("-", "_")
 
-    impl = globals().get(py_name + '_impl')
+    impl = globals().get(py_name + "_impl")
     if impl is None:
         die('no such subcommand "{}"'.format(settings.subcommand))
 

--- a/toasty/collection.py
+++ b/toasty/collection.py
@@ -103,8 +103,10 @@ class SimpleFitsCollection(ImageCollection):
 
         for fits_path in self._paths:
             with fits.open(fits_path) as hdul:
-                if self._hdu_index is not None:
+                if isinstance(self._hdu_index, int):
                     hdu = hdul[self._hdu_index]
+                elif self._hdu_index is not None:
+                    hdu = hdul[self._hdu_index[self._paths.index(fits_path)]]
                 else:
                     for hdu in hdul:
                         if (hasattr(hdu, 'shape') and len(hdu.shape) > 1

--- a/toasty/collection.py
+++ b/toasty/collection.py
@@ -125,6 +125,22 @@ class SimpleFitsCollection(ImageCollection):
                         f"cannot process input `{fits_path}`: Did not find any HDU with image data"
                     )
 
+                # Hack for DASCH files, and potentially others. These have TPV
+                # polynomial distortions but do not use the magic projection
+                # keyword that causes Astropy to accept them. We don't try to be
+                # very flexible in how we activate the hack since we don't want
+                # to futz with things unnecessarily.
+
+                if (
+                    "PV1_5" in hdu.header
+                    and hdu.header["CTYPE1"] == "RA---TAN"
+                    and hdu.header["CTYPE2"] == "DEC--TAN"
+                ):
+                    hdu.header["CTYPE1"] = "RA---TPV"
+                    hdu.header["CTYPE2"] = "DEC--TPV"
+
+                # End hack(s).
+
                 wcs = WCS(hdu.header)
                 shape = hdu.shape
 

--- a/toasty/fits_tiler.py
+++ b/toasty/fits_tiler.py
@@ -56,8 +56,6 @@ class FitsTiler:
             package="toasty",
         )
 
-        in_dir = self._create_hipsgen_input_dir(fits)
-
         if hdu_index is None:
             hdu_index_args = []
         else:
@@ -67,29 +65,30 @@ class FitsTiler:
                 arg = "hdu=" + ",".join(str(i) for i in hdu_index)
             hdu_index_args = [arg]
 
-        argv = [
-            "java",
-            "-jar",
-            "{0}".format(hipsgen_path),
-            "in={0}".format(in_dir.name),
-            "out={0}".format(out_dir),
-            "creator_did=ivo://aas.wwt.toasty/{0}".format(out_dir),
-        ]
-        argv += hdu_index_args
-        argv += ["INDEX", "TILES"]
+        with self._create_hipsgen_input_dir(fits) as in_dir_path:
+            argv = [
+                "java",
+                "-jar",
+                "{0}".format(hipsgen_path),
+                "in={0}".format(in_dir_path),
+                "out={0}".format(out_dir),
+                "creator_did=ivo://aas.wwt.toasty/{0}".format(out_dir),
+            ]
+            argv += hdu_index_args
+            argv += ["INDEX", "TILES"]
 
-        p = Popen(
-            argv,
-            stdout=PIPE,
-            stderr=STDOUT,
-            shell=True,
-        )
+            p = Popen(
+                argv,
+                stdout=PIPE,
+                stderr=STDOUT,
+                shell=True,
+            )
 
-        # Even if we don't want to print the output, this loop is still useful since it waits until the HiPSgen process
-        # is completed.
-        for line in p.stdout:
-            if cli_progress:
-                print(line.decode("UTF-8"))
+            # Even if we don't want to print the output, this loop is still useful since it waits until the HiPSgen process
+            # is completed.
+            for line in p.stdout:
+                if cli_progress:
+                    print(line.decode("UTF-8"))
 
         pio = pyramid.PyramidIO(out_dir, default_format="fits")
         bld = builder.Builder(pio)

--- a/toasty/fits_tiler.py
+++ b/toasty/fits_tiler.py
@@ -1,0 +1,161 @@
+# -*- mode: python; coding: utf-8 -*-
+# Copyright 2013-2021 Chris Beaumont and the AAS WorldWide Telescope project
+# Licensed under the MIT License.
+
+from astropy.coordinates import Angle
+from astropy.io import fits
+from astropy.utils.data import download_file
+from astropy.wcs import WCS
+import ntpath
+import os
+import reproject
+from shutil import copyfile
+from subprocess import Popen, PIPE, STDOUT, run
+import tempfile
+
+from toasty import builder, collection, pyramid, multi_tan, multi_wcs
+from wwt_data_formats.enums import ProjectionType
+
+
+class FitsTiler:
+
+    def tile_tan(self, fits, out_dir, hdu_index, cli_progress, **kwargs):
+        pio = pyramid.PyramidIO(out_dir, default_format='fits')
+        bld = builder.Builder(pio)
+        coll = collection.SimpleFitsCollection(fits, hdu_index=hdu_index, **kwargs)
+
+        if coll._is_multi_tan():
+            if cli_progress:
+                print('Tiling base layer (Step 1 of 2)')
+            tile_processor = multi_tan.MultiTanProcessor(coll)
+            tile_processor.compute_global_pixelization(bld)
+            tile_processor.tile(pio, cli_progress=cli_progress, **kwargs)
+        else:
+            if cli_progress:
+                print('Tiling base layer (Step 1 of 2)')
+
+            tile_processor = multi_wcs.MultiWcsProcessor(coll)
+            tile_processor.compute_global_pixelization(bld)
+            tile_processor.tile(pio, reproject.reproject_interp, cli_progress=cli_progress, **kwargs)
+
+        if cli_progress:
+            print('Downsampling (Step 2 of 2)')
+        bld.cascade(cli_progress=cli_progress, **kwargs)
+
+        # Using the file name of the first FITS file as the image collection name
+        bld.set_name(out_dir.split('/')[-1])
+        bld.write_index_rel_wtml()
+
+        return out_dir, bld
+
+    def tile_hips(self, fits, out_dir, hdu_index, cli_progress):
+        in_dir = self._create_hipsgen_input_dir(fits)
+
+        hipsgen_path = 'lib/Hipsgen.jar'
+        if not os.path.exists(hipsgen_path):
+            if cli_progress:
+                print('Downloading HiPSgen')
+            cache_path = download_file('http://aladin.unistra.fr/java/Hipsgen.jar',
+                                       show_progress=cli_progress,
+                                       cache=True)
+            # Copying the cached file to local directory because of repeated issues with the hipsgen.jar file being
+            # deleted inside the cache.
+            if not os.path.isdir('lib'):
+                os.mkdir('lib')
+
+            copyfile(cache_path, 'lib/Hipsgen.jar')
+
+        hdu_index_parameter = ''
+        if hdu_index is not None:
+            hdu_index_parameter = 'hdu='
+            if isinstance(hdu_index, int):
+                for i in range(len(fits)):
+                    hdu_index_parameter += '{0},'.format(hdu_index)
+            else:
+                for i in range(len(hdu_index)):
+                    hdu_index_parameter += '{0},'.format(hdu_index[i])
+
+            hdu_index_parameter = hdu_index_parameter[:-1]
+
+        p = Popen(['java', '-jar', '{0}'.format(hipsgen_path), 'in={0}'.format(in_dir.name), 'out={0}'.format(out_dir),
+                   'creator_did=ivo://aas.wwt.toasty/{0}'.format(out_dir), hdu_index_parameter, 'INDEX', 'TILES'],
+                  stdout=PIPE, stderr=STDOUT, shell=True)
+
+        # Even if we don't want to print the output, this loop is still useful since it waits until the HiPSgen process
+        # is completed.
+        for line in p.stdout:
+            if cli_progress:
+                print(line.decode('UTF-8'))
+
+        pio = pyramid.PyramidIO(out_dir, default_format='fits')
+        bld = builder.Builder(pio)
+        bld = self.copy_hips_properties_to_builder(bld, out_dir)
+        bld.write_index_rel_wtml()
+        return out_dir, bld
+
+    def fits_covers_large_area(self, fits_list, hdu_index=None):
+        corners = []
+
+        for fits_path in fits_list:
+            with fits.open(fits_path) as hdul:
+                hdu = None
+                if hdu_index is None:
+                    for hdu in hdul:
+                        if (hasattr(hdu, 'shape') and len(hdu.shape) > 1
+                                and type(hdu) is not fits.hdu.table.BinTableHDU):
+                            break
+                elif isinstance(hdu_index, int):
+                    hdu = hdul[hdu_index]
+                else:
+                    hdu = hdul[hdu_index[fits_list.index(fits_path)]]
+
+                wcs = WCS(hdu.header)
+                corners.append(wcs.pixel_to_world(0, 0))
+                corners.append(wcs.pixel_to_world(hdu.shape[0], 0))
+                corners.append(wcs.pixel_to_world(hdu.shape[0], hdu.shape[1]))
+                corners.append(wcs.pixel_to_world(0, hdu.shape[1]))
+                
+        max_distance = Angle('0d')
+        for compare_index in range(len(corners)):
+            for index in range(compare_index + 1, len(corners)):
+                distance = corners[compare_index].separation(corners[index])
+                if distance > max_distance:
+                    max_distance = distance
+                    
+        return max_distance > Angle('20d')
+
+    def is_java_installed(self):
+        java_version = run(['java', '-version'], capture_output=True, text=True)
+        # For some unknown reason, this output is captured on stderr
+        return "java version" in java_version.stdout.lower() or "java version" in java_version.stderr.lower()
+
+    def _create_hipsgen_input_dir(self, fits_list):
+        dir = tempfile.TemporaryDirectory()
+        for fits_file in fits_list:
+            link_name = ntpath.basename(fits_file)
+            absolute_path = os.path.join(os.getcwd(), fits_file)
+            link_path = os.path.join(dir.name, link_name)
+            if not os.path.exists(link_path):
+                os.symlink(src=absolute_path, dst=link_path)
+
+        return dir
+
+    def copy_hips_properties_to_builder(self, bld, out_dir):
+        hips_properties = dict()
+        with open('{0}/properties'.format(out_dir)) as prop:
+            for line in prop:
+                if line[0] != '#':
+                    key_value_pair = line.split('=')
+                    hips_properties[key_value_pair[0].strip()] = key_value_pair[1].strip()
+        bld.set_name(out_dir.split('/')[-1])
+        bld.imgset.projection = ProjectionType.HEALPIX
+        bld.imgset.file_type = "fits"
+        bld.imgset.tile_levels = int(hips_properties['hips_order'])
+        bld.place.dec_deg = float(hips_properties['hips_initial_dec'])
+        bld.place.ra_hr = float(hips_properties['hips_initial_ra']) / 15.0
+        bld.place.zoom_level = float(hips_properties['hips_initial_fov'])
+        bld.imgset.center_x = float(hips_properties['hips_initial_ra'])
+        bld.imgset.center_y = float(hips_properties['hips_initial_dec'])
+        bld.imgset.base_degrees_per_tile = float(hips_properties['hips_initial_fov'])
+        bld.imgset.url = 'Norder{0}/Dir{1}/Npix{2}'
+        return bld

--- a/toasty/fits_tiler.py
+++ b/toasty/fits_tiler.py
@@ -81,7 +81,7 @@ class FitsTiler:
                 argv,
                 stdout=PIPE,
                 stderr=STDOUT,
-                shell=True,
+                shell=False,
             )
 
             # Even if we don't want to print the output, this loop is still useful since it waits until the HiPSgen process
@@ -89,6 +89,13 @@ class FitsTiler:
             for line in p.stdout:
                 if cli_progress:
                     print(line.decode("UTF-8"))
+
+            if p.wait() != 0:
+                if cli_progress:
+                    m = "see its output printed above"
+                else:
+                    m = "set `cli_progress=True` to see its output"
+                raise Exception(f"an error occurred running hipsgen; {m}")
 
         pio = pyramid.PyramidIO(out_dir, default_format="fits")
         bld = builder.Builder(pio)

--- a/toasty/fits_tiler.py
+++ b/toasty/fits_tiler.py
@@ -65,13 +65,17 @@ class FitsTiler:
                 arg = "hdu=" + ",".join(str(i) for i in hdu_index)
             hdu_index_args = [arg]
 
+        # If we give hipsgen a relative output directory it will end up
+        # inside `in_dir`
+        abs_out_dir = os.path.abspath(out_dir)
+
         with self._create_hipsgen_input_dir(fits) as in_dir_path:
             argv = [
                 "java",
                 "-jar",
                 "{0}".format(hipsgen_path),
                 "in={0}".format(in_dir_path),
-                "out={0}".format(out_dir),
+                "out={0}".format(abs_out_dir),
                 "creator_did=ivo://aas.wwt.toasty/{0}".format(out_dir),
             ]
             argv += hdu_index_args

--- a/toasty/fits_tiler.py
+++ b/toasty/fits_tiler.py
@@ -18,32 +18,33 @@ from wwt_data_formats.enums import ProjectionType
 
 
 class FitsTiler:
-
     def tile_tan(self, fits, out_dir, hdu_index, cli_progress, **kwargs):
-        pio = pyramid.PyramidIO(out_dir, default_format='fits')
+        pio = pyramid.PyramidIO(out_dir, default_format="fits")
         bld = builder.Builder(pio)
         coll = collection.SimpleFitsCollection(fits, hdu_index=hdu_index, **kwargs)
 
         if coll._is_multi_tan():
             if cli_progress:
-                print('Tiling base layer (Step 1 of 2)')
+                print("Tiling base layer (Step 1 of 2)")
             tile_processor = multi_tan.MultiTanProcessor(coll)
             tile_processor.compute_global_pixelization(bld)
             tile_processor.tile(pio, cli_progress=cli_progress, **kwargs)
         else:
             if cli_progress:
-                print('Tiling base layer (Step 1 of 2)')
+                print("Tiling base layer (Step 1 of 2)")
 
             tile_processor = multi_wcs.MultiWcsProcessor(coll)
             tile_processor.compute_global_pixelization(bld)
-            tile_processor.tile(pio, reproject.reproject_interp, cli_progress=cli_progress, **kwargs)
+            tile_processor.tile(
+                pio, reproject.reproject_interp, cli_progress=cli_progress, **kwargs
+            )
 
         if cli_progress:
-            print('Downsampling (Step 2 of 2)')
+            print("Downsampling (Step 2 of 2)")
         bld.cascade(cli_progress=cli_progress, **kwargs)
 
         # Using the file name of the first FITS file as the image collection name
-        bld.set_name(out_dir.split('/')[-1])
+        bld.set_name(out_dir.split("/")[-1])
         bld.write_index_rel_wtml()
 
         return out_dir, bld
@@ -51,43 +52,58 @@ class FitsTiler:
     def tile_hips(self, fits, out_dir, hdu_index, cli_progress):
         in_dir = self._create_hipsgen_input_dir(fits)
 
-        hipsgen_path = 'lib/Hipsgen.jar'
+        hipsgen_path = "lib/Hipsgen.jar"
         if not os.path.exists(hipsgen_path):
             if cli_progress:
-                print('Downloading HiPSgen')
-            cache_path = download_file('http://aladin.unistra.fr/java/Hipsgen.jar',
-                                       show_progress=cli_progress,
-                                       cache=True)
+                print("Downloading HiPSgen")
+            cache_path = download_file(
+                "http://aladin.unistra.fr/java/Hipsgen.jar",
+                show_progress=cli_progress,
+                cache=True,
+            )
             # Copying the cached file to local directory because of repeated issues with the hipsgen.jar file being
             # deleted inside the cache.
-            if not os.path.isdir('lib'):
-                os.mkdir('lib')
+            if not os.path.isdir("lib"):
+                os.mkdir("lib")
 
-            copyfile(cache_path, 'lib/Hipsgen.jar')
+            copyfile(cache_path, "lib/Hipsgen.jar")
 
-        hdu_index_parameter = ''
+        hdu_index_parameter = ""
         if hdu_index is not None:
-            hdu_index_parameter = 'hdu='
+            hdu_index_parameter = "hdu="
             if isinstance(hdu_index, int):
                 for i in range(len(fits)):
-                    hdu_index_parameter += '{0},'.format(hdu_index)
+                    hdu_index_parameter += "{0},".format(hdu_index)
             else:
                 for i in range(len(hdu_index)):
-                    hdu_index_parameter += '{0},'.format(hdu_index[i])
+                    hdu_index_parameter += "{0},".format(hdu_index[i])
 
             hdu_index_parameter = hdu_index_parameter[:-1]
 
-        p = Popen(['java', '-jar', '{0}'.format(hipsgen_path), 'in={0}'.format(in_dir.name), 'out={0}'.format(out_dir),
-                   'creator_did=ivo://aas.wwt.toasty/{0}'.format(out_dir), hdu_index_parameter, 'INDEX', 'TILES'],
-                  stdout=PIPE, stderr=STDOUT, shell=True)
+        p = Popen(
+            [
+                "java",
+                "-jar",
+                "{0}".format(hipsgen_path),
+                "in={0}".format(in_dir.name),
+                "out={0}".format(out_dir),
+                "creator_did=ivo://aas.wwt.toasty/{0}".format(out_dir),
+                hdu_index_parameter,
+                "INDEX",
+                "TILES",
+            ],
+            stdout=PIPE,
+            stderr=STDOUT,
+            shell=True,
+        )
 
         # Even if we don't want to print the output, this loop is still useful since it waits until the HiPSgen process
         # is completed.
         for line in p.stdout:
             if cli_progress:
-                print(line.decode('UTF-8'))
+                print(line.decode("UTF-8"))
 
-        pio = pyramid.PyramidIO(out_dir, default_format='fits')
+        pio = pyramid.PyramidIO(out_dir, default_format="fits")
         bld = builder.Builder(pio)
         bld = self.copy_hips_properties_to_builder(bld, out_dir)
         bld.write_index_rel_wtml()
@@ -101,8 +117,11 @@ class FitsTiler:
                 hdu = None
                 if hdu_index is None:
                     for hdu in hdul:
-                        if (hasattr(hdu, 'shape') and len(hdu.shape) > 1
-                                and type(hdu) is not fits.hdu.table.BinTableHDU):
+                        if (
+                            hasattr(hdu, "shape")
+                            and len(hdu.shape) > 1
+                            and type(hdu) is not fits.hdu.table.BinTableHDU
+                        ):
                             break
                 elif isinstance(hdu_index, int):
                     hdu = hdul[hdu_index]
@@ -114,20 +133,23 @@ class FitsTiler:
                 corners.append(wcs.pixel_to_world(hdu.shape[0], 0))
                 corners.append(wcs.pixel_to_world(hdu.shape[0], hdu.shape[1]))
                 corners.append(wcs.pixel_to_world(0, hdu.shape[1]))
-                
-        max_distance = Angle('0d')
+
+        max_distance = Angle("0d")
         for compare_index in range(len(corners)):
             for index in range(compare_index + 1, len(corners)):
                 distance = corners[compare_index].separation(corners[index])
                 if distance > max_distance:
                     max_distance = distance
-                    
-        return max_distance > Angle('20d')
+
+        return max_distance > Angle("20d")
 
     def is_java_installed(self):
-        java_version = run(['java', '-version'], capture_output=True, text=True)
+        java_version = run(["java", "-version"], capture_output=True, text=True)
         # For some unknown reason, this output is captured on stderr
-        return "java version" in java_version.stdout.lower() or "java version" in java_version.stderr.lower()
+        return (
+            "java version" in java_version.stdout.lower()
+            or "java version" in java_version.stderr.lower()
+        )
 
     def _create_hipsgen_input_dir(self, fits_list):
         dir = tempfile.TemporaryDirectory()
@@ -142,20 +164,22 @@ class FitsTiler:
 
     def copy_hips_properties_to_builder(self, bld, out_dir):
         hips_properties = dict()
-        with open('{0}/properties'.format(out_dir)) as prop:
+        with open("{0}/properties".format(out_dir)) as prop:
             for line in prop:
-                if line[0] != '#':
-                    key_value_pair = line.split('=')
-                    hips_properties[key_value_pair[0].strip()] = key_value_pair[1].strip()
-        bld.set_name(out_dir.split('/')[-1])
+                if line[0] != "#":
+                    key_value_pair = line.split("=")
+                    hips_properties[key_value_pair[0].strip()] = key_value_pair[
+                        1
+                    ].strip()
+        bld.set_name(out_dir.split("/")[-1])
         bld.imgset.projection = ProjectionType.HEALPIX
         bld.imgset.file_type = "fits"
-        bld.imgset.tile_levels = int(hips_properties['hips_order'])
-        bld.place.dec_deg = float(hips_properties['hips_initial_dec'])
-        bld.place.ra_hr = float(hips_properties['hips_initial_ra']) / 15.0
-        bld.place.zoom_level = float(hips_properties['hips_initial_fov'])
-        bld.imgset.center_x = float(hips_properties['hips_initial_ra'])
-        bld.imgset.center_y = float(hips_properties['hips_initial_dec'])
-        bld.imgset.base_degrees_per_tile = float(hips_properties['hips_initial_fov'])
-        bld.imgset.url = 'Norder{0}/Dir{1}/Npix{2}'
+        bld.imgset.tile_levels = int(hips_properties["hips_order"])
+        bld.place.dec_deg = float(hips_properties["hips_initial_dec"])
+        bld.place.ra_hr = float(hips_properties["hips_initial_ra"]) / 15.0
+        bld.place.zoom_level = float(hips_properties["hips_initial_fov"])
+        bld.imgset.center_x = float(hips_properties["hips_initial_ra"])
+        bld.imgset.center_y = float(hips_properties["hips_initial_dec"])
+        bld.imgset.base_degrees_per_tile = float(hips_properties["hips_initial_fov"])
+        bld.imgset.url = "Norder{0}/Dir{1}/Npix{2}"
         return bld

--- a/toasty/fits_tiler.py
+++ b/toasty/fits_tiler.py
@@ -49,23 +49,14 @@ class FitsTiler:
         return out_dir, bld
 
     def tile_hips(self, fits, out_dir, hdu_index, cli_progress):
+        hipsgen_path = download_file(
+            "https://aladin.unistra.fr/java/Hipsgen.jar",
+            show_progress=cli_progress,
+            cache=True,
+            package="toasty",
+        )
+
         in_dir = self._create_hipsgen_input_dir(fits)
-
-        hipsgen_path = "lib/Hipsgen.jar"
-        if not os.path.exists(hipsgen_path):
-            if cli_progress:
-                print("Downloading HiPSgen")
-            cache_path = download_file(
-                "http://aladin.unistra.fr/java/Hipsgen.jar",
-                show_progress=cli_progress,
-                cache=True,
-            )
-            # Copying the cached file to local directory because of repeated issues with the hipsgen.jar file being
-            # deleted inside the cache.
-            if not os.path.isdir("lib"):
-                os.mkdir("lib")
-
-            copyfile(cache_path, "lib/Hipsgen.jar")
 
         hdu_index_parameter = ""
         if hdu_index is not None:

--- a/toasty/fits_tiler.py
+++ b/toasty/fits_tiler.py
@@ -58,30 +58,28 @@ class FitsTiler:
 
         in_dir = self._create_hipsgen_input_dir(fits)
 
-        hdu_index_parameter = ""
-        if hdu_index is not None:
-            hdu_index_parameter = "hdu="
+        if hdu_index is None:
+            hdu_index_args = []
+        else:
             if isinstance(hdu_index, int):
-                for i in range(len(fits)):
-                    hdu_index_parameter += "{0},".format(hdu_index)
+                arg = "hdu=" + ",".join([str(hdu_index)] * len(fits))
             else:
-                for i in range(len(hdu_index)):
-                    hdu_index_parameter += "{0},".format(hdu_index[i])
+                arg = "hdu=" + ",".join(str(i) for i in hdu_index)
+            hdu_index_args = [arg]
 
-            hdu_index_parameter = hdu_index_parameter[:-1]
+        argv = [
+            "java",
+            "-jar",
+            "{0}".format(hipsgen_path),
+            "in={0}".format(in_dir.name),
+            "out={0}".format(out_dir),
+            "creator_did=ivo://aas.wwt.toasty/{0}".format(out_dir),
+        ]
+        argv += hdu_index_args
+        argv += ["INDEX", "TILES"]
 
         p = Popen(
-            [
-                "java",
-                "-jar",
-                "{0}".format(hipsgen_path),
-                "in={0}".format(in_dir.name),
-                "out={0}".format(out_dir),
-                "creator_did=ivo://aas.wwt.toasty/{0}".format(out_dir),
-                hdu_index_parameter,
-                "INDEX",
-                "TILES",
-            ],
+            argv,
             stdout=PIPE,
             stderr=STDOUT,
             shell=True,

--- a/toasty/fits_tiler.py
+++ b/toasty/fits_tiler.py
@@ -144,11 +144,12 @@ class FitsTiler:
         return max_distance > Angle("20d")
 
     def is_java_installed(self):
-        java_version = run(["java", "-version"], capture_output=True, text=True)
-        # For some unknown reason, this output is captured on stderr
+        java_version = run(
+            ["java", "-version"], capture_output=True, text=True, check=True
+        )
         return (
-            "java version" in java_version.stdout.lower()
-            or "java version" in java_version.stderr.lower()
+            "version" in java_version.stdout.lower()
+            or "version" in java_version.stderr.lower()
         )
 
     def _create_hipsgen_input_dir(self, fits_list):

--- a/toasty/fits_tiler.py
+++ b/toasty/fits_tiler.py
@@ -2,84 +2,243 @@
 # Copyright 2013-2021 Chris Beaumont and the AAS WorldWide Telescope project
 # Licensed under the MIT License.
 
-from astropy.coordinates import Angle
-from astropy.io import fits
-from astropy.utils.data import download_file
-from astropy.wcs import WCS
+"""
+Tools for automagically tiling FITS files.
+
+Instead of using these interfaces directly, most users should probably use the
+all-in-one function :func:`toasty.tile_fits`.
+"""
+
 import os.path
-import reproject
-from shutil import copyfile
 from subprocess import Popen, PIPE, STDOUT, run
 import tempfile
 
-from toasty import builder, collection, pyramid, multi_tan, multi_wcs
+from astropy.coordinates import Angle
+from astropy.utils.data import download_file
+import reproject
 from wwt_data_formats.enums import ProjectionType
 
+from toasty import builder, pyramid, multi_tan, multi_wcs
 
-class FitsTiler:
-    def tile_tan(self, fits, out_dir, hdu_index, cli_progress, **kwargs):
-        pio = pyramid.PyramidIO(out_dir, default_format="fits")
-        bld = builder.Builder(pio)
-        coll = collection.SimpleFitsCollection(fits, hdu_index=hdu_index, **kwargs)
+__all__ = [
+    "FitsTiler",
+]
 
-        if coll._is_multi_tan():
+
+class FitsTiler(object):
+    """
+    A class to manage the tiling of a FITS file collection.
+
+    Parameters
+    ----------
+    coll : :class:`~toasty.collection.ImageCollection`
+        A collection of one or more input FITS files
+    out_dir : optional str, default None
+        The output directory for the tiled FITS data.
+        If None, a sensible default next to the first input file
+        will be chosen.
+    force_hipsgen : optional bool, default False
+        If true, the tiling process will be forced to use the
+        HiPS format and the ``hipsgen`` tool.
+    force_tan : optional bool, default False
+        If true, the tiling process will be forced to target the
+        WWT "study" format with a tangential projection.
+    """
+
+    coll = None
+    "The input :class:`~toasty.collection.ImageCollection`."
+
+    out_dir = None
+    """The output directory.
+
+    This can be set upon creation or left as None. If the latter, this attribute
+    will be filled in after a successful invocation of the :meth:`tile` method.
+    """
+
+    force_hipsgen = False
+    """Whether the tiling process will be forced to use the HiPS format and the
+    ``hipsgen`` tool."""
+
+    force_tan = False
+    """Whether the tiling process will be forced to target the WWT "study"
+    format with a tangential projection."""
+
+    builder = None
+    """A :class:`~toasty.builder.Builder` describing the output dataset.
+
+    This attribute is None upon creation of a class instance. It will be filled
+    in after a successful invocation of the :meth:`tile` method.
+    """
+
+    def __init__(
+        self,
+        coll,
+        out_dir=None,
+        force_hipsgen=False,
+        force_tan=False,
+    ):
+        self.coll = coll
+        self.out_dir = out_dir
+        self.force_hipsgen = force_hipsgen
+        self.force_tan = force_tan
+
+    def should_use_hipsgen(self):
+        """
+        Determine whether the tiling process should use ``hipsgen``.
+        """
+        return self.force_hipsgen or (
+            self._fits_covers_large_area()
+            and self._is_java_installed()
+            and not self.force_tan
+        )
+
+    def tile(
+        self,
+        cli_progress=False,
+        override=False,
+        **kwargs,
+    ):
+        """
+        Process the collection into a tile pyramid using either a common
+        tangential projection or HiPSgen.
+
+        Parameters
+        ----------
+        cli_progress : optional boolean, defaults to False
+            If true, progress messages will be printed as the FITS files
+            are being processed.
+        override : optional boolean, defaults to False
+            By default, if the output directory already exists, the tiling
+            process is skipped. If this argument is true, an existing
+            output directory will be deleted if it exists.
+        kwargs
+            Settings for the tiling process. For example, ``blankval``.
+
+        Returns
+        -------
+        Self.
+
+        Notes
+        -----
+        After this function returns, the attributes :attr:`out_dir` and
+        :attr:`builder` of *self* will be fully initialized.
+        """
+
+        use_hipsgen = self.should_use_hipsgen()
+
+        if self.out_dir is None:
+            # Kind of hacky here ... Note that export_simple() might return a
+            # generator so we can't just index the return value.
+            for tup in self.coll.export_simple():
+                first_fits_path = tup[0]
+                break
+
+            first_file_name = first_fits_path.split(".gz")[0]
+            self.out_dir = first_file_name[: first_file_name.rfind(".")] + "_tiled"
+
+            if use_hipsgen:
+                self.out_dir += "_HiPS"
+
+        if cli_progress:
+            print(f"Tile output directory is `{self.out_dir}`")
+
+        pio = pyramid.PyramidIO(self.out_dir, default_format="fits")
+        self.builder = builder.Builder(pio)
+        self.builder.set_name(self.out_dir.split("/")[-1])
+
+        if os.path.isdir(self.out_dir):
+            if override:
+                if cli_progress:
+                    print(f"Tile directory already exists -- removing")
+
+                import shutil
+
+                shutil.rmtree(self.out_dir)
+            else:
+                if cli_progress:
+                    print("Tile directory already exists -- reusing")
+
+                if os.path.exists(os.path.join(self.out_dir, "properties")):
+                    self._copy_hips_properties_to_builder()
+
+                return
+
+        if use_hipsgen:
+            self._tile_hips(cli_progress)
+        else:
+            self._tile_tan(cli_progress, **kwargs)
+
+        self.builder.write_index_rel_wtml()
+        return self
+
+    def _tile_tan(self, cli_progress, **kwargs):
+        if self.coll._is_multi_tan():
             if cli_progress:
                 print("Tiling base layer in multi-TAN mode (step 1 of 2)")
-            tile_processor = multi_tan.MultiTanProcessor(coll)
-            tile_processor.compute_global_pixelization(bld)
-            tile_processor.tile(pio, cli_progress=cli_progress, **kwargs)
+
+            tile_processor = multi_tan.MultiTanProcessor(self.coll)
+            tile_processor.compute_global_pixelization(self.builder)
+            tile_processor.tile(self.builder.pio, cli_progress=cli_progress, **kwargs)
         else:
             if cli_progress:
                 print("Tiling base layer in multi-WCS mode (step 1 of 2)")
 
-            tile_processor = multi_wcs.MultiWcsProcessor(coll)
-            tile_processor.compute_global_pixelization(bld)
+            tile_processor = multi_wcs.MultiWcsProcessor(self.coll)
+            tile_processor.compute_global_pixelization(self.builder)
             tile_processor.tile(
-                pio, reproject.reproject_interp, cli_progress=cli_progress, **kwargs
+                self.builder.pio,
+                reproject.reproject_interp,
+                cli_progress=cli_progress,
+                **kwargs,
             )
 
         if cli_progress:
             print("Downsampling (step 2 of 2)")
-        bld.cascade(cli_progress=cli_progress, **kwargs)
 
-        # Using the file name of the first FITS file as the image collection name
-        bld.set_name(out_dir.split("/")[-1])
-        bld.write_index_rel_wtml()
+        self.builder.cascade(cli_progress=cli_progress, **kwargs)
 
-        return out_dir, bld
-
-    def tile_hips(self, fits, out_dir, hdu_index, cli_progress):
+    def _tile_hips(self, cli_progress):
         hipsgen_path = download_file(
             "https://aladin.unistra.fr/java/Hipsgen.jar",
             show_progress=cli_progress,
             cache=True,
-            package="toasty",
+            pkgname="toasty",
         )
 
-        if hdu_index is None:
-            hdu_index_args = []
-        else:
-            if isinstance(hdu_index, int):
-                arg = "hdu=" + ",".join([str(hdu_index)] * len(fits))
-            else:
-                arg = "hdu=" + ",".join(str(i) for i in hdu_index)
-            hdu_index_args = [arg]
+        # Get the "simple export" version of the collection that we can pass to
+        # hipsgen.
+
+        try:
+            export_info = self.coll.export_simple()
+        except Exception as e:
+            raise Exception(
+                'cannot export FITS collection in "simple" mode for passing to hipsgen'
+            ) from e
+
+        fits_paths = []
+        hdu_indexes = []
+
+        for tup in export_info:
+            fits_paths.append(tup[0])
+            hdu_indexes.append(str(tup[1]))
 
         # If we give hipsgen a relative output directory it will end up
         # inside `in_dir`
-        abs_out_dir = os.path.abspath(out_dir)
+        abs_out_dir = os.path.abspath(self.out_dir)
+        out_base = os.path.basename(self.out_dir)
 
-        with self._create_hipsgen_input_dir(fits) as in_dir_path:
+        with self._create_hipsgen_input_dir(fits_paths) as in_dir_path:
             argv = [
                 "java",
                 "-jar",
                 "{0}".format(hipsgen_path),
                 "in={0}".format(in_dir_path),
                 "out={0}".format(abs_out_dir),
-                "creator_did=ivo://aas.wwt.toasty/{0}".format(out_dir),
+                "creator_did=ivo://aas.wwt.toasty/{0}".format(out_base),
+                "hdu={0}".format(",".join(hdu_indexes)),
+                "INDEX",
+                "TILES",
             ]
-            argv += hdu_index_args
-            argv += ["INDEX", "TILES"]
 
             p = Popen(
                 argv,
@@ -92,7 +251,7 @@ class FitsTiler:
             # is completed.
             for line in p.stdout:
                 if cli_progress:
-                    print(line.decode("UTF-8"))
+                    print(line.decode("UTF-8"), end="")
 
             if p.wait() != 0:
                 if cli_progress:
@@ -101,45 +260,32 @@ class FitsTiler:
                     m = "set `cli_progress=True` to see its output"
                 raise Exception(f"an error occurred running hipsgen; {m}")
 
-        if not os.path.isdir(out_dir):
+        if not os.path.isdir(self.out_dir):
             if cli_progress:
                 m = "see its output printed above"
             else:
                 m = "set `cli_progress=True` to see its output"
             raise Exception(
-                f"output directory `{out_dir}` does not exist, meaning `hipsgen` probably failed; {m}"
+                f"output directory `{self.out_dir}` does not exist, meaning `hipsgen` probably failed; {m}"
             )
 
-        pio = pyramid.PyramidIO(out_dir, default_format="fits")
-        bld = builder.Builder(pio)
-        bld = self.copy_hips_properties_to_builder(bld, out_dir)
-        bld.write_index_rel_wtml()
-        return out_dir, bld
+        self._copy_hips_properties_to_builder()
 
-    def fits_covers_large_area(self, fits_list, hdu_index=None):
+    def _fits_covers_large_area(self):
+        """
+        Here, "large" means "large enough that the TAN projection 'study' mode
+        yields visually unacceptable results."
+        """
         corners = []
 
-        for fits_path in fits_list:
-            with fits.open(fits_path) as hdul:
-                hdu = None
-                if hdu_index is None:
-                    for hdu in hdul:
-                        if (
-                            hasattr(hdu, "shape")
-                            and len(hdu.shape) > 1
-                            and type(hdu) is not fits.hdu.table.BinTableHDU
-                        ):
-                            break
-                elif isinstance(hdu_index, int):
-                    hdu = hdul[hdu_index]
-                else:
-                    hdu = hdul[hdu_index[fits_list.index(fits_path)]]
+        for desc in self.coll.descriptions():
+            corners.append(desc.wcs.pixel_to_world(0, 0))
+            corners.append(desc.wcs.pixel_to_world(desc.shape[0], 0))
+            corners.append(desc.wcs.pixel_to_world(desc.shape[0], desc.shape[1]))
+            corners.append(desc.wcs.pixel_to_world(0, desc.shape[1]))
 
-                wcs = WCS(hdu.header)
-                corners.append(wcs.pixel_to_world(0, 0))
-                corners.append(wcs.pixel_to_world(hdu.shape[0], 0))
-                corners.append(wcs.pixel_to_world(hdu.shape[0], hdu.shape[1]))
-                corners.append(wcs.pixel_to_world(0, hdu.shape[1]))
+        # This is a naive N^2 search but the input would have to be pretty
+        # pathological for it to make sense to try to be more efficient here.
 
         max_distance = Angle("0d")
         for compare_index in range(len(corners)):
@@ -150,7 +296,7 @@ class FitsTiler:
 
         return max_distance > Angle("20d")
 
-    def is_java_installed(self):
+    def _is_java_installed(self):
         java_version = run(
             ["java", "-version"], capture_output=True, text=True, check=True
         )
@@ -170,24 +316,26 @@ class FitsTiler:
 
         return dir
 
-    def copy_hips_properties_to_builder(self, bld, out_dir):
+    def _copy_hips_properties_to_builder(self):
         hips_properties = dict()
-        with open("{0}/properties".format(out_dir)) as prop:
+
+        with open(os.path.join(self.out_dir, "properties")) as prop:
             for line in prop:
                 if line[0] != "#":
                     key_value_pair = line.split("=")
                     hips_properties[key_value_pair[0].strip()] = key_value_pair[
                         1
                     ].strip()
-        bld.set_name(out_dir.split("/")[-1])
-        bld.imgset.projection = ProjectionType.HEALPIX
-        bld.imgset.file_type = "fits"
-        bld.imgset.tile_levels = int(hips_properties["hips_order"])
-        bld.place.dec_deg = float(hips_properties["hips_initial_dec"])
-        bld.place.ra_hr = float(hips_properties["hips_initial_ra"]) / 15.0
-        bld.place.zoom_level = float(hips_properties["hips_initial_fov"])
-        bld.imgset.center_x = float(hips_properties["hips_initial_ra"])
-        bld.imgset.center_y = float(hips_properties["hips_initial_dec"])
-        bld.imgset.base_degrees_per_tile = float(hips_properties["hips_initial_fov"])
-        bld.imgset.url = "Norder{0}/Dir{1}/Npix{2}"
-        return bld
+
+        self.builder.imgset.projection = ProjectionType.HEALPIX
+        self.builder.imgset.file_type = "fits"
+        self.builder.imgset.tile_levels = int(hips_properties["hips_order"])
+        self.builder.place.dec_deg = float(hips_properties["hips_initial_dec"])
+        self.builder.place.ra_hr = float(hips_properties["hips_initial_ra"]) / 15.0
+        self.builder.place.zoom_level = float(hips_properties["hips_initial_fov"])
+        self.builder.imgset.center_x = float(hips_properties["hips_initial_ra"])
+        self.builder.imgset.center_y = float(hips_properties["hips_initial_dec"])
+        self.builder.imgset.base_degrees_per_tile = float(
+            hips_properties["hips_initial_fov"]
+        )
+        self.builder.imgset.url = "Norder{0}/Dir{1}/Npix{2}"

--- a/toasty/fits_tiler.py
+++ b/toasty/fits_tiler.py
@@ -24,13 +24,13 @@ class FitsTiler:
 
         if coll._is_multi_tan():
             if cli_progress:
-                print("Tiling base layer (Step 1 of 2)")
+                print("Tiling base layer in multi-TAN mode (step 1 of 2)")
             tile_processor = multi_tan.MultiTanProcessor(coll)
             tile_processor.compute_global_pixelization(bld)
             tile_processor.tile(pio, cli_progress=cli_progress, **kwargs)
         else:
             if cli_progress:
-                print("Tiling base layer (Step 1 of 2)")
+                print("Tiling base layer in multi-WCS mode (step 1 of 2)")
 
             tile_processor = multi_wcs.MultiWcsProcessor(coll)
             tile_processor.compute_global_pixelization(bld)
@@ -39,7 +39,7 @@ class FitsTiler:
             )
 
         if cli_progress:
-            print("Downsampling (Step 2 of 2)")
+            print("Downsampling (step 2 of 2)")
         bld.cascade(cli_progress=cli_progress, **kwargs)
 
         # Using the file name of the first FITS file as the image collection name

--- a/toasty/fits_tiler.py
+++ b/toasty/fits_tiler.py
@@ -101,6 +101,15 @@ class FitsTiler:
                     m = "set `cli_progress=True` to see its output"
                 raise Exception(f"an error occurred running hipsgen; {m}")
 
+        if not os.path.isdir(out_dir):
+            if cli_progress:
+                m = "see its output printed above"
+            else:
+                m = "set `cli_progress=True` to see its output"
+            raise Exception(
+                f"output directory `{out_dir}` does not exist, meaning `hipsgen` probably failed; {m}"
+            )
+
         pio = pyramid.PyramidIO(out_dir, default_format="fits")
         bld = builder.Builder(pio)
         bld = self.copy_hips_properties_to_builder(bld, out_dir)

--- a/toasty/fits_tiler.py
+++ b/toasty/fits_tiler.py
@@ -6,8 +6,7 @@ from astropy.coordinates import Angle
 from astropy.io import fits
 from astropy.utils.data import download_file
 from astropy.wcs import WCS
-import ntpath
-import os
+import os.path
 import reproject
 from shutil import copyfile
 from subprocess import Popen, PIPE, STDOUT, run
@@ -154,12 +153,12 @@ class FitsTiler:
 
     def _create_hipsgen_input_dir(self, fits_list):
         dir = tempfile.TemporaryDirectory()
+
         for fits_file in fits_list:
-            link_name = ntpath.basename(fits_file)
-            absolute_path = os.path.join(os.getcwd(), fits_file)
+            link_name = os.path.basename(fits_file)
+            absolute_path = os.path.abspath(fits_file)
             link_path = os.path.join(dir.name, link_name)
-            if not os.path.exists(link_path):
-                os.symlink(src=absolute_path, dst=link_path)
+            os.symlink(src=absolute_path, dst=link_path)
 
         return dir
 


### PR DESCRIPTION
- Now using HiPSgen for large angular areas
- hdu_index can now be a list of ints (one int for every fits)
- tile_fits does not tile if there is already a tiled version of the desired projection in out_dir. This can be overridden by the 'override'  parameter
- fits_covers_large_area is now doing the brute force version of comparing all corners with every other corner, so with many fits files as input there could be quite a few comparisons. But I’m thinking this is still insignificant compared to the actual tiling process.