### PR TITLE
Allow astropy to fix non-standard FITS headers

### DIFF
--- a/toasty/collection.py
+++ b/toasty/collection.py
@@ -184,7 +184,7 @@ class SimpleFitsCollection(ImageCollection):
 
             # End hack(s).
 
-            wcs = WCS(hdu.header, fix=False)
+            wcs = WCS(hdu.header)
             shape = hdu.shape
 
             # We need to make sure the data are 2D celestial, since that's


### PR DESCRIPTION
Warnings are emitted by astropy if any header changes are made.

Not allowing astropy to try fix the wcs can cause ugly crashes for some FITS files, [like these.](http://hst.esac.esa.int/ehst-sl-server/servlet/data-action?RETRIEVAL_TYPE=PRODUCT&OBSERVATION_ID=w0hj0501t)

Here is an example error if fixing is not allowed:
```
astropy.wcs._wcs.SingularMatrixError: ERROR 3 in wcsset() at line 2739 of file cextern\wcslib\C\wcs.c:
Linear transformation matrix is singular.
ERROR 3 in linset() at line 718 of file cextern\wcslib\C\lin.c:
PCi_ja matrix is singular.
```

@pkgw Are you aware of why WCS fixing has been set to False? I've not seen anything obvious breaking by allowing fixing, but maybe there is or was some valid reason for introducing this limitation?
