### PR TITLE
Add some more AVM checks and compute constellations

### DIFF
--- a/docs/cli/check-avm.rst
+++ b/docs/cli/check-avm.rst
@@ -28,14 +28,16 @@ successful.
 
 .. _WCS: https://fits.gsfc.nasa.gov/fits_wcs.html
 
-By default, only the presence of AVM data is reported. If the ``--print`` or
-``-p`` option is given, the AVM data will be dumped out.
+By default, the presence of AVM data is reported along with some information
+about the agreement between the AVM and the image shape. If the ``--print`` or
+``-p`` option is given, the actual AVM data will be dumped out.
 
 If the ``--exitcode`` option is given, the exit code of the command line tool
-will reflect whether AVM data were found. Zero (success) means that data were
-found, while nonzero (failure) indicates that no data were present, the data
-were corrupt, or that some other failure occurred. Without this option, the exit
-code will be zero if the image can be opened but contains no AVM data.
+will reflect whether spatial AVM data were found. Zero (success) means that
+spatial data were found, while nonzero (failure) indicates that no data were
+present, the data were corrupt, or that some other failure occurred. Without
+this option, the exit code will be zero if the image can be opened but contains
+no AVM data.
 
 
 Notes

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # -*- mode: python; coding: utf-8 -*-
-# Copyright 2013-2020 Chris Beaumont and the AAS WorldWide Telescope team
+# Copyright 2013-2022 Chris Beaumont and the AAS WorldWide Telescope team
 # Licensed under the MIT License
 
 from __future__ import absolute_import, division, print_function
@@ -78,7 +78,7 @@ setup_args = dict(
         "reproject",
         "shapely",
         "tqdm>=4.0",
-        "wwt_data_formats>=0.12",
+        "wwt_data_formats>=0.13",
     ],
     extras_require={
         "test": [

--- a/toasty/tests/test_avm.py
+++ b/toasty/tests/test_avm.py
@@ -12,22 +12,24 @@ from .. import cli
 class TestAvm(object):
     def setup_method(self, method):
         from tempfile import mkdtemp
+
         self.work_dir = mkdtemp()
 
     def teardown_method(self, method):
         from shutil import rmtree
+
         rmtree(self.work_dir)
 
     def work_path(self, *pieces):
         return os.path.join(self.work_dir, *pieces)
 
-    @pytest.mark.skipif('not HAS_AVM')
+    @pytest.mark.skipif("not HAS_AVM")
     def test_check_cli_bad(self):
         args = [
-            'check-avm',
-            '--print',
-            '--exitcode',
-            test_path('badavm-type.png'),
+            "check-avm",
+            "--print",
+            "--exitcode",
+            test_path("badavm-type.png"),
         ]
 
         try:
@@ -35,14 +37,19 @@ class TestAvm(object):
         except SystemExit as e:
             assert e.code == 1
         else:
-            assert False, 'no error exit on bad AVM'
+            assert False, "no error exit on bad AVM"
 
-    @pytest.mark.skipif('not HAS_AVM')
+    @pytest.mark.skipif("not HAS_AVM")
     def test_check_cli_good(self):
         args = [
-            'check-avm',
-            '--print',
-            test_path('geminiann11015a.jpg'),
+            "check-avm",
+            "--print",
+            test_path("geminiann11015a.jpg"),
         ]
 
-        cli.entrypoint(args)
+        try:
+            cli.entrypoint(args)
+        except SystemExit as e:
+            assert e.code == 0
+        else:
+            assert False, "error exit on good AVM"

--- a/toasty/tests/test_multi_tan.py
+++ b/toasty/tests/test_multi_tan.py
@@ -40,6 +40,7 @@ class TestMultiTan(object):
     <Place
         Angle="0"
         AngularSize="0"
+        Constellation="VIR"
         DataSetType="Sky"
         Dec="0.7438249862258411"
         Magnitude="0"

--- a/toasty/tests/test_study.py
+++ b/toasty/tests/test_study.py
@@ -126,6 +126,7 @@ class TestStudy(object):
     <Place
         Angle="0"
         AngularSize="0"
+        Constellation="GRU"
         DataSetType="Sky"
         Dec="-42.58752472831171"
         Magnitude="0"
@@ -204,6 +205,7 @@ class TestStudy(object):
     <Place
         Angle="0"
         AngularSize="0"
+        Constellation="GRU"
         DataSetType="Sky"
         Dec="-42.58752472831171"
         Magnitude="0"


### PR DESCRIPTION
Here we augment the `check-avm` tool to provide slightly more verbose information about the AVM information in an image, specifically whether spatial information is present and/or seems to be correct for the image in question.

We also start requiring `wwt_data_formats >= 0.13`, which adds support for correctly computing constellation information for Places. We get these "for free" since these get computed automatically by the APIs we use.