### PR TITLE
Properly match/propagate diagonal PC headers in multi-tan processing

### DIFF
--- a/toasty/collection.py
+++ b/toasty/collection.py
@@ -41,6 +41,10 @@ MATCH_HEADERS = [
     "CRVAL2",
     "CDELT1",
     "CDELT2",
+    "PC1_1",
+    "PC1_2",
+    "PC2_1",
+    "PC2_2",
 ]
 
 
@@ -108,7 +112,9 @@ class ImageCollection(ABC):
                 ref_headers = {}
 
                 for h in MATCH_HEADERS:
-                    ref_headers[h] = header[h]
+                    value = header.get(h)
+                    if value is not None:
+                        ref_headers[h] = value
 
                 if (
                     ref_headers["CTYPE1"] != "RA---TAN"
@@ -116,8 +122,7 @@ class ImageCollection(ABC):
                 ):
                     return False
             else:
-                for h in MATCH_HEADERS:
-                    expected = ref_headers[h]
+                for h, expected in ref_headers.items():
                     observed = header[h]
 
                     if observed != expected:

--- a/toasty/multi_tan.py
+++ b/toasty/multi_tan.py
@@ -31,6 +31,8 @@ MATCH_HEADERS = [
 # np.isclose() or whatever it is.
 SAVE_HEADERS = [
     "PC1_1",
+    "PC1_2",
+    "PC2_1",
     "PC2_2",
 ]
 
@@ -97,7 +99,9 @@ class MultiTanProcessor(object):
                     ref_headers[h] = header[h]
 
                 for h in SAVE_HEADERS:
-                    ref_headers[h] = header[h]
+                    value = header.get(h)
+                    if value is not None:
+                        ref_headers[h] = value
 
                 if ref_headers["CTYPE1"] != "RA---TAN":
                     raise Exception(


### PR DESCRIPTION
We were losing rotation information in the multi-tan processing! We just need to honor the diagonal PC headers if they're present. Other than that, it looks like we're loading the WCS in the deep field sample ... at least, we agree with DS9.

CC @astrodavid10.