### PR TITLE
WCS sampling & FITS to TOAST FITS

### DIFF
--- a/docs/api/toasty.TilingMethod.rst
+++ b/docs/api/toasty.TilingMethod.rst
@@ -1,0 +1,25 @@
+TilingMethod
+============
+
+.. currentmodule:: toasty
+
+.. autoclass:: TilingMethod
+   :show-inheritance:
+
+   .. rubric:: Attributes Summary
+
+   .. autosummary::
+
+      ~TilingMethod.AUTO_DETECT
+      ~TilingMethod.HIPS
+      ~TilingMethod.TAN
+      ~TilingMethod.TOAST
+      ~TilingMethod.UNTILED
+
+   .. rubric:: Attributes Documentation
+
+   .. autoattribute:: AUTO_DETECT
+   .. autoattribute:: HIPS
+   .. autoattribute:: TAN
+   .. autoattribute:: TOAST
+   .. autoattribute:: UNTILED

--- a/docs/api/toasty.fits_tiler.FitsTiler.rst
+++ b/docs/api/toasty.fits_tiler.FitsTiler.rst
@@ -12,26 +12,22 @@ FitsTiler
 
       ~FitsTiler.builder
       ~FitsTiler.coll
-      ~FitsTiler.force_hipsgen
-      ~FitsTiler.force_tan
+      ~FitsTiler.tiling_method
       ~FitsTiler.out_dir
 
    .. rubric:: Methods Summary
 
    .. autosummary::
 
-      ~FitsTiler.should_use_hipsgen
       ~FitsTiler.tile
 
    .. rubric:: Attributes Documentation
 
    .. autoattribute:: builder
    .. autoattribute:: coll
-   .. autoattribute:: force_hipsgen
-   .. autoattribute:: force_tan
+   .. autoattribute:: tiling_method
    .. autoattribute:: out_dir
 
    .. rubric:: Methods Documentation
 
-   .. automethod:: should_use_hipsgen
    .. automethod:: tile

--- a/docs/api/toasty.pyramid.get_parents.rst
+++ b/docs/api/toasty.pyramid.get_parents.rst
@@ -1,0 +1,6 @@
+get_parents
+===========
+
+.. currentmodule:: toasty.pyramid
+
+.. autofunction:: get_parents

--- a/docs/api/toasty.pyramid.guess_base_layer_level.rst
+++ b/docs/api/toasty.pyramid.guess_base_layer_level.rst
@@ -1,0 +1,6 @@
+guess_base_layer_level
+======================
+
+.. currentmodule:: toasty.pyramid
+
+.. autofunction:: guess_base_layer_level

--- a/docs/api/toasty.samplers.WcsSampler.rst
+++ b/docs/api/toasty.samplers.WcsSampler.rst
@@ -1,0 +1,19 @@
+WcsSampler
+==========
+
+.. currentmodule:: toasty.samplers
+
+.. autoclass:: WcsSampler
+   :show-inheritance:
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~WcsSampler.filter
+      ~WcsSampler.sampler
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: filter
+   .. automethod:: sampler

--- a/docs/cli/view.rst
+++ b/docs/cli/view.rst
@@ -78,7 +78,7 @@ launching the viewer without rerunning the tiling process.
 The FITS data will be tiled either onto a common tangential projection, or into
 a TOAST, depending on the angular size subtended by the data. If any of the
 FITS image corners are separated by more than 20 degrees, the TOAST format will
-be used. Otherwise, Toasty's will reproject the input data into a tangential
+be used. Otherwise, Toasty will reproject the input data into a tangential
 (gnomonic) projection if necessary.
 
 

--- a/docs/cli/view.rst
+++ b/docs/cli/view.rst
@@ -76,13 +76,11 @@ assumes that the image was already successfully tiled, and skips straight to
 launching the viewer without rerunning the tiling process.
 
 The FITS data will be tiled either onto a common tangential projection, or into
-a HiPS format using `hipsgen`_, depending on the angular size subtended by the
-data. If any of the FITS image corners are separated by more than 20 degrees and
-Java is available, `hipsgen`_ will be used. Otherwise, Toasty's internal
-processing will be used, reprojecting the input data into a tangential
+a TOAST, depending on the angular size subtended by the data. If any of the
+FITS image corners are separated by more than 20 degrees, the TOAST format will
+be used. Otherwise, Toasty's will reproject the input data into a tangential
 (gnomonic) projection if necessary.
 
-.. _hipsgen: https://aladin.u-strasbg.fr/hips/HipsIn10Steps.gml
 
 
 See Also

--- a/toasty/__init__.py
+++ b/toasty/__init__.py
@@ -7,7 +7,18 @@ from __future__ import absolute_import, division, print_function
 
 __all__ = [
     "tile_fits",
+    "TilingMethod",
 ]
+
+from enum import Enum
+
+
+class TilingMethod(Enum):
+    UNTILED = 1
+    TAN = 2
+    TOAST = 3
+    HIPS = 4
+    AUTO_DETECT = 5
 
 
 def tile_fits(
@@ -16,13 +27,13 @@ def tile_fits(
     hdu_index=None,
     override=False,
     cli_progress=False,
-    force_hipsgen=False,
-    force_tan=False,
+    tiling_method=TilingMethod.AUTO_DETECT,
     blankval=None,
     **kwargs
 ):
     """
-    Process a file or a list of FITS files into a tile pyramid using either a common tangential projection, TOAST, or HiPSgen.
+    Process a file or a list of FITS files into a tile pyramid in the form of either a common tangential projection,
+    TOAST, or HiPS.
 
     Parameters
     ----------
@@ -40,14 +51,9 @@ def tile_fits(
         served. To override the content in *out_dir*, set *override* to True.
     cli_progress : optional boolean, defaults to False
         If true, progress messages will be printed as the FITS files are being processed.
-    force_hipsgen : optional boolean, defaults to False
-        Force usage of HiPSgen tiling over tangential projection. If this and *force_tan* are set to False, this method
-        will figure out when to use the different projections. Tangential projection for smaller angular areas and
-        TOAST larger regions of the sky.
-    force_tan : optional boolean, defaults to False
-        Force usage of tangential projection tiling over HiPSgen. If this and *force_hipsgen* are set to False, this
-        method will figure out when to use the different projections. Tangential projection for smaller angular areas
-        and TOAST larger regions of the sky.
+    tiling_method : optional :class:`~toasty.TilingMethod`
+        Can be used to force a specific tiling method, i.e. tiled tangential projection, TOAST, or HiPS. Defatults to
+        auto detection, which choses the most apropriate method.
     blankval : optional number, default None
         An image value to treat as undefined in all FITS inputs.
     kwargs
@@ -67,8 +73,7 @@ def tile_fits(
     tiler = fits_tiler.FitsTiler(
         coll,
         out_dir=out_dir,
-        force_hipsgen=force_hipsgen,
-        force_tan=force_tan,
+        tiling_method=tiling_method,
     )
     tiler.tile(cli_progress=cli_progress, override=override, **kwargs)
     return tiler.out_dir, tiler.builder

--- a/toasty/__init__.py
+++ b/toasty/__init__.py
@@ -27,6 +27,7 @@ def tile_fits(
     hdu_index=None,
     override=False,
     cli_progress=False,
+    parallel=None,
     tiling_method=TilingMethod.AUTO_DETECT,
     blankval=None,
     **kwargs
@@ -51,6 +52,11 @@ def tile_fits(
         served. To override the content in *out_dir*, set *override* to True.
     cli_progress : optional boolean, defaults to False
         If true, progress messages will be printed as the FITS files are being processed.
+    parallel : integer or None (the default)
+        The level of parallelization to use. If unspecified, defaults to using
+        all CPUs. If the OS does not support fork-based multiprocessing,
+        parallel processing is not possible and serial processing will be
+        forced. Pass ``1`` to force serial processing.
     tiling_method : optional :class:`~toasty.TilingMethod`
         Can be used to force a specific tiling method, i.e. tiled tangential projection, TOAST, or HiPS. Defatults to
         auto detection, which choses the most apropriate method.
@@ -75,5 +81,7 @@ def tile_fits(
         out_dir=out_dir,
         tiling_method=tiling_method,
     )
-    tiler.tile(cli_progress=cli_progress, override=override, **kwargs)
+    tiler.tile(
+        cli_progress=cli_progress, parallel=parallel, override=override, **kwargs
+    )
     return tiler.out_dir, tiler.builder

--- a/toasty/__init__.py
+++ b/toasty/__init__.py
@@ -22,7 +22,7 @@ def tile_fits(
     **kwargs
 ):
     """
-    Process a file or a list of FITS files into a tile pyramid using either a common tangential projection or HiPSgen.
+    Process a file or a list of FITS files into a tile pyramid using either a common tangential projection, TOAST, or HiPSgen.
 
     Parameters
     ----------
@@ -43,15 +43,15 @@ def tile_fits(
     force_hipsgen : optional boolean, defaults to False
         Force usage of HiPSgen tiling over tangential projection. If this and *force_tan* are set to False, this method
         will figure out when to use the different projections. Tangential projection for smaller angular areas and
-        HiPSgen larger regions of the sky.
+        TOAST larger regions of the sky.
     force_tan : optional boolean, defaults to False
         Force usage of tangential projection tiling over HiPSgen. If this and *force_hipsgen* are set to False, this
         method will figure out when to use the different projections. Tangential projection for smaller angular areas
-        and HiPSgen larger regions of the sky.
+        and TOAST larger regions of the sky.
     blankval : optional number, default None
         An image value to treat as undefined in all FITS inputs.
     kwargs
-        Settings for the tiling process. For example, ``blankval``.
+        Settings for the tiling process.
 
     Returns
     -------

--- a/toasty/__init__.py
+++ b/toasty/__init__.py
@@ -58,8 +58,8 @@ def tile_fits(
         parallel processing is not possible and serial processing will be
         forced. Pass ``1`` to force serial processing.
     tiling_method : optional :class:`~toasty.TilingMethod`
-        Can be used to force a specific tiling method, i.e. tiled tangential projection, TOAST, or HiPS. Defatults to
-        auto detection, which choses the most apropriate method.
+        Can be used to force a specific tiling method, i.e. tiled tangential projection, TOAST, or HiPS. Defaults to
+        auto-detection, which choses the most appropriate method.
     blankval : optional number, default None
         An image value to treat as undefined in all FITS inputs.
     kwargs

--- a/toasty/_libtoasty.pyx
+++ b/toasty/_libtoasty.pyx
@@ -123,3 +123,148 @@ def subsample(ul, ur, lr, ll, npix, increasing):
     _ll = Point(DTYPE(ll[0]), DTYPE(ll[1]))
     _subsample(_ul, _ur, _lr, _ll, x, y, increasing)
     return x, y
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef void _order_pair_1d(np.ndarray[DTYPE_t, ndim=1] arr, int i, int j):
+    """
+    Swap two elements of a 1D array to ensure that that arr[i] < arr[j].
+    """
+    cdef DTYPE_t z
+
+    if arr[i] > arr[j]:
+        z = arr[j]
+        arr[j] = arr[i]
+        arr[i] = z
+
+
+DEF TWOPI = 6.28318530717958623200
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef bint _tile_intersects_latlon_bbox(
+    np.ndarray[DTYPE_t, ndim=2] corner_lonlats,
+    DTYPE_t bbox_lon_min,
+    DTYPE_t bbox_lon_max,
+    DTYPE_t bbox_lat_min,
+    DTYPE_t bbox_lat_max
+):
+    """
+    Return true if a tile seems to intersect a bounding box.
+
+    This function is implemented in Cython because the np.min/max calls turn out
+    to become relatively expensive when this function is called millions of times.
+    """
+
+    # Latitudes are easy -- no wrapping.
+
+    cdef DTYPE_t tile_lat_min = corner_lonlats[0,1]
+    cdef DTYPE_t tile_lat_max = tile_lat_min
+    cdef DTYPE_t x = 0
+
+    for i in range(1, 4):
+        x = corner_lonlats[i, 1]
+        if x < tile_lat_min:
+            tile_lat_min = x
+        if x > tile_lat_max:
+            tile_lat_max = x
+
+    if bbox_lat_min > tile_lat_max:
+        return False
+    if bbox_lat_max < tile_lat_min:
+        return False
+
+    # Can't reject based on latitudes. Longitudes are trickier.
+    #
+    # Step 1: If we hit one of the poles, longitudes become
+    # ~meaningless, so all we can really do (in our simplistic approach
+    # here) is accept the tile. We compare to ~(pi - 1e-8) here to
+    # account for inevitable roundoff. Note that if we don't apply the
+    # lat-bounds filter first, every single chunk will accept tiles at
+    # the poles, even if it's right on the equator.
+
+    if tile_lat_max > 1.5707963 or tile_lat_min < -1.5707963:
+        return True
+
+    # Step 2: get good a coverage range for tile longitudes. Some tiles
+    # span a full pi in longitude, and sometimes the "corners"
+    # longitudes span all sorts of values from -2pi to 2pi. We need to
+    # shuffle them around to get self-consistent values.
+    #
+    # We do this by sorting the longitudes and adjusting by 2pi until
+    # the difference between the maximum and minimum longitudes is
+    # less than or equal to pi (which we know a priori is as big as
+    # it should ever be). In particular, if the condition isn't met,
+    # we add 2pi to the smallest longitude and try again.
+
+    cdef np.ndarray[DTYPE_t, ndim=1] lons = corner_lonlats[:, 0]
+
+    # This "sorting network" always delivers a sorted list:
+
+    _order_pair_1d(lons, 0, 2)
+    _order_pair_1d(lons, 1, 3)
+    _order_pair_1d(lons, 0, 1)
+    _order_pair_1d(lons, 2, 3)
+    _order_pair_1d(lons, 1, 2)
+
+    # Now shuffle. After adjusting the lowest longitude, we
+    # re-insert it into the list in the appropriate spot.
+
+    cdef DTYPE_t updated_lon = 0
+
+    while lons[3] - lons[0] > np.pi:
+        updated_lon = lons[0] + TWOPI
+
+        for i in range(3):
+            if lons[i + 1] > updated_lon:
+                lons[i] = updated_lon
+                break
+
+            # Shift the current element to the left since the
+            # new longitude is going to be placed somewhere
+            # ahead of it.
+            lons[i] = lons[i + 1]
+        else:
+            # This code is invoked if we don't break out of
+            # the loop -- i.e., if updated_lon is the new
+            # maximum value.
+            lons[3] = updated_lon
+
+    cdef DTYPE_t tile_lon_min = lons[0]
+    cdef DTYPE_t tile_lon_max = lons[3]
+
+    # Step 3: Now, shuffle the tile longitudes so that the left edge of the
+    # tile is to the right of the left edge of the bounding box. We might drag it
+    # to the left (in chunks of 360 degrees) if it's really far to the
+    # right.
+
+    while tile_lon_min < bbox_lon_min:
+        tile_lon_min += TWOPI
+        tile_lon_max += TWOPI
+
+    while tile_lon_min - bbox_lon_min > TWOPI:
+        tile_lon_min -= TWOPI
+        tile_lon_max -= TWOPI
+
+    # Step 4. Now we can test. In this configuration, if the left edge of
+    # the tile is not clear of the right edge of the bounding box, there's an
+    # overlap.
+
+    if tile_lon_min < bbox_lon_max:
+        return True
+
+    # But we must also check for wraparound! If we imagine that the image is
+    # duplicated at its current position + 2pi radians, if the right edge of
+    # the tile passes the "next" left edge of the bounding box, we also overlap.
+
+    if tile_lon_max > bbox_lon_min + TWOPI:
+        return True
+
+    # Otherwise, there is no overlap.
+
+    return False
+
+def tile_intersects_latlon_bbox(corner_lonlats, bbox_lon_min, bbox_lon_max, bbox_lat_min, bbox_lat_max):
+    return _tile_intersects_latlon_bbox(corner_lonlats, bbox_lon_min, bbox_lon_max, bbox_lat_min, bbox_lat_max)

--- a/toasty/builder.py
+++ b/toasty/builder.py
@@ -202,7 +202,7 @@ class Builder(object):
         return img
 
     def toast_base(self, sampler, depth, is_planet=False, is_pano=False, **kwargs):
-        from .toast import sample_layer, ToastCoordinateSystem
+        from .toast import sample_layer, sample_layer_filtered, ToastCoordinateSystem
 
         self._check_no_wcs_yet()
 
@@ -212,7 +212,12 @@ class Builder(object):
             else ToastCoordinateSystem.ASTRONOMICAL
         )
         coordsys = kwargs.pop("coordsys", coordsys)
-        sample_layer(self.pio, sampler, depth, coordsys=coordsys, **kwargs)
+        if "tile_filter" in kwargs:
+            sample_layer_filtered(
+                pio=self.pio, sampler=sampler, depth=depth, coordsys=coordsys, **kwargs
+            )
+        else:
+            sample_layer(self.pio, sampler, depth, coordsys=coordsys, **kwargs)
 
         if is_planet:
             self.imgset.data_set_type = DataSetType.PLANET

--- a/toasty/builder.py
+++ b/toasty/builder.py
@@ -274,9 +274,9 @@ class Builder(object):
 
     def apply_wcs_info(self, wcs, width, height):
         self.imgset.set_position_from_wcs(
-            wcs.to_header(),
-            width,
-            height,
+            headers=wcs.to_header(),
+            width=width,
+            height=height,
             place=self.place,
         )
 
@@ -320,10 +320,17 @@ class Builder(object):
         self.place.name = name
         return self
 
-    def create_wtml_folder(self):
+    def create_wtml_folder(self, add_place_for_toast=False):
         """
         Create a one-item :class:`wwt_data_formats.folder.Folder` object
         capturing this image.
+
+        Parameters
+        ----------
+        add_place_for_toast : optional boolean, defaults to False
+            All-sky/all-planet datasets usually don't want to be associated with a
+            particular Place. Otherwise, loading up the imageset causes the view
+            to zoom to a particular RA/Dec or lat/lon, likely 0,0.
         """
         from wwt_data_formats.folder import Folder
 
@@ -334,22 +341,17 @@ class Builder(object):
         folder = Folder()
         folder.name = self.imgset.name
 
-        # For all-sky/all-planet datasets, don't associate the imageset with a
-        # particular Place. Otherwise, loading up the imageset causes the view
-        # to zoom to a particular RA/Dec or lat/lon, likely 0,0. We might want
-        # to make this manually configurable but this heuristic should Do The
-        # Right Thing most times.
-        if self.imgset.projection == ProjectionType.TOAST:
+        if self.imgset.projection == ProjectionType.TOAST and not add_place_for_toast:
             folder.children = [self.imgset]
         else:
             folder.children = [self.place]
 
         return folder
 
-    def write_index_rel_wtml(self):
+    def write_index_rel_wtml(self, add_place_for_toast=False):
         from wwt_data_formats import write_xml_doc
 
-        folder = self.create_wtml_folder()
+        folder = self.create_wtml_folder(add_place_for_toast=add_place_for_toast)
 
         with self.pio.open_metadata_for_write("index_rel.wtml") as f:
             write_xml_doc(folder.to_xml(), dest_stream=f, dest_wants_bytes=True)

--- a/toasty/cli.py
+++ b/toasty/cli.py
@@ -893,7 +893,7 @@ def view_impl(settings):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         tiler = FitsTiler(coll)
-        tiler.tile(cli_progress=True)
+        tiler.tile(cli_progress=True, parallel=settings.parallelism)
 
     preview_wtml(
         os.path.join(tiler.out_dir, "index_rel.wtml"),

--- a/toasty/collection.py
+++ b/toasty/collection.py
@@ -187,6 +187,17 @@ class SimpleFitsCollection(ImageCollection):
                 hdu.header["CTYPE1"] = "RA---TPV"
                 hdu.header["CTYPE2"] = "DEC--TPV"
 
+                # Extra hack (?) for `rh04475_00_01ww_tnx.fit` needed to fix 180
+                # deg rotation. Based on the last paragraph of \S2.2 in
+                # Calabretta & Greisen (2002), I think the headers in this file
+                # are wrong. This presumably also applies to other DASCH files
+                # that cross the north pole; possibly an issue in wcstools,
+                # which is the WCS kit used for this project. I'm not currently
+                # able to get my hands on other DASCH files to test out other
+                # cases where this fix may be needed.
+                if hdu.header["CRVAL2"] == 90:
+                    hdu.header["LONPOLE"] = 180.0
+
             # End hack(s).
 
             wcs = WCS(hdu.header)

--- a/toasty/fits_tiler.py
+++ b/toasty/fits_tiler.py
@@ -388,11 +388,19 @@ class FitsTiler(object):
         self.builder.imgset.base_degrees_per_tile = float(
             hips_properties["hips_initial_fov"]
         )
-        pixel_cut = hips_properties["hips_pixel_cut"].split(" ")
-        self.builder.imgset.pixel_cut_low = float(pixel_cut[0])
-        self.builder.imgset.pixel_cut_high = float(pixel_cut[1])
-        data_range = hips_properties["hips_data_range"].split(" ")
-        self.builder.imgset.data_min = float(data_range[0])
-        self.builder.imgset.data_max = float(data_range[1])
+
+        pixel_cut = hips_properties.get("hips_pixel_cut")
+
+        if pixel_cut is not None:
+            pixel_cut = pixel_cut.split(" ")
+            self.builder.imgset.pixel_cut_low = float(pixel_cut[0])
+            self.builder.imgset.pixel_cut_high = float(pixel_cut[1])
+
+        data_range = hips_properties.get("hips_data_range")
+
+        if data_range is not None:
+            data_range = data_range.split(" ")
+            self.builder.imgset.data_min = float(data_range[0])
+            self.builder.imgset.data_max = float(data_range[1])
 
         self.builder.imgset.url = "Norder{0}/Dir{1}/Npix{2}"

--- a/toasty/fits_tiler.py
+++ b/toasty/fits_tiler.py
@@ -70,10 +70,12 @@ class FitsTiler(object):
         coll,
         out_dir=None,
         tiling_method=TilingMethod.AUTO_DETECT,
+        add_place_for_toast=True,
     ):
         self.coll = coll
         self.out_dir = out_dir
         self.tiling_method = tiling_method
+        self.add_place_for_toast = add_place_for_toast
 
         if self.tiling_method == TilingMethod.AUTO_DETECT:
             if self._fits_covers_large_area():
@@ -165,7 +167,9 @@ class FitsTiler(object):
         else:
             self._tile_tan(cli_progress, parallel, **kwargs)
 
-        self.builder.write_index_rel_wtml()
+        self.builder.write_index_rel_wtml(
+            add_place_for_toast=self.add_place_for_toast,
+        )
         return self
 
     def _tile_tan(self, cli_progress, parallel, **kwargs):

--- a/toasty/fits_tiler.py
+++ b/toasty/fits_tiler.py
@@ -74,11 +74,12 @@ class FitsTiler(object):
         self.coll = coll
         self.out_dir = out_dir
         self.tiling_method = tiling_method
-        if (
-            self.tiling_method == TilingMethod.AUTO_DETECT
-            and self._fits_covers_large_area()
-        ):
-            self.tiling_method == TilingMethod.TOAST
+
+        if self.tiling_method == TilingMethod.AUTO_DETECT:
+            if self._fits_covers_large_area():
+                self.tiling_method = TilingMethod.TOAST
+            else:
+                self.tiling_method = TilingMethod.TAN
 
     def tile(
         self,

--- a/toasty/fits_tiler.py
+++ b/toasty/fits_tiler.py
@@ -19,8 +19,7 @@ from astropy.utils.data import download_file
 import reproject
 from wwt_data_formats.enums import ProjectionType
 
-from . import builder, pyramid, multi_tan, multi_wcs
-from .__init__ import TilingMethod
+from . import builder, pyramid, multi_tan, multi_wcs, TilingMethod
 
 
 __all__ = [
@@ -41,7 +40,7 @@ class FitsTiler(object):
         If None, a sensible default next to the first input file
         will be chosen.
     tiling_method : optional :class:`~toasty.TilingMethod`
-         Whether the tiling process will auto detected or manually
+         Whether the tiling process will be auto-detected or manually
          chosen. Defaults to auto detection based on the angular
          size of the imageset.
     """
@@ -57,7 +56,7 @@ class FitsTiler(object):
     """
 
     tiling_method = TilingMethod.AUTO_DETECT
-    """Whether the tiling process will auto detected or manually chosen."""
+    """Whether the tiling process will be auto-detected or manually chosen."""
 
     builder = None
     """A :class:`~toasty.builder.Builder` describing the output dataset.
@@ -84,7 +83,7 @@ class FitsTiler(object):
         **kwargs,
     ):
         """
-        Process the collection into a tile pyramid, either a common
+        Process the collection into a tile pyramid, using either a common
         tangential projection, TOAST, or HiPS.
 
         Parameters
@@ -201,10 +200,8 @@ class FitsTiler(object):
                 wcs = image.wcs
             break
 
-        if "start" in kwargs:
-            start = kwargs["start"]
-            kwargs.pop("start", None)
-        else:
+        start = kwargs.pop("start", None)
+        if start is None:
             start = pyramid.guess_base_layer_level(wcs=wcs, cli_progress=cli_progress)
 
         from .samplers import WcsSampler

--- a/toasty/fits_tiler.py
+++ b/toasty/fits_tiler.py
@@ -19,7 +19,9 @@ from astropy.utils.data import download_file
 import reproject
 from wwt_data_formats.enums import ProjectionType
 
-from toasty import TilingMethod, builder, pyramid, multi_tan, multi_wcs
+from . import builder, pyramid, multi_tan, multi_wcs
+from .__init__ import TilingMethod
+
 
 __all__ = [
     "FitsTiler",

--- a/toasty/fits_tiler.py
+++ b/toasty/fits_tiler.py
@@ -321,13 +321,16 @@ class FitsTiler(object):
         return max_distance > Angle("20d")
 
     def _is_java_installed(self):
-        java_version = run(
-            ["java", "-version"], capture_output=True, text=True, check=True
-        )
-        return (
-            "version" in java_version.stdout.lower()
-            or "version" in java_version.stderr.lower()
-        )
+        try:
+            java_version = run(
+                ["java", "-version"], capture_output=True, text=True, check=True
+            )
+            return (
+                "version" in java_version.stdout.lower()
+                or "version" in java_version.stderr.lower()
+            )
+        except:
+            return False
 
     def _create_hipsgen_input_dir(self, fits_list):
         dir = tempfile.TemporaryDirectory()

--- a/toasty/fits_tiler.py
+++ b/toasty/fits_tiler.py
@@ -74,6 +74,11 @@ class FitsTiler(object):
         self.coll = coll
         self.out_dir = out_dir
         self.tiling_method = tiling_method
+        if (
+            self.tiling_method == TilingMethod.AUTO_DETECT
+            and self._fits_covers_large_area()
+        ):
+            self.tiling_method == TilingMethod.TOAST
 
     def tile(
         self,
@@ -125,6 +130,8 @@ class FitsTiler(object):
 
             if self.tiling_method == TilingMethod.HIPS:
                 self.out_dir += "_HiPS"
+            if self.tiling_method == TilingMethod.TOAST:
+                self.out_dir += "_TOAST"
 
         if cli_progress:
             print(f"Tile output directory is `{self.out_dir}`")
@@ -152,10 +159,7 @@ class FitsTiler(object):
 
         if self.tiling_method == TilingMethod.HIPS:
             self._tile_hips(cli_progress, parallel)
-        elif self.tiling_method == TilingMethod.TOAST or (
-            self.tiling_method == TilingMethod.AUTO_DETECT
-            and self._fits_covers_large_area()
-        ):
+        elif self.tiling_method == TilingMethod.TOAST:
             self._tile_toast(cli_progress, parallel, **kwargs)
         else:
             self._tile_tan(cli_progress, parallel, **kwargs)

--- a/toasty/fits_tiler.py
+++ b/toasty/fits_tiler.py
@@ -216,7 +216,7 @@ class FitsTiler(object):
         self.builder.toast_base(
             sampler,
             start,
-            cli_progress=True,
+            cli_progress=cli_progress,
             tile_filter=tile_filter,
             parallel=parallel,
         )

--- a/toasty/merge.py
+++ b/toasty/merge.py
@@ -271,12 +271,12 @@ def _cascade_images_parallel(pio, start, merger, cli_progress, parallel, tile_fi
             if pos.n == first_level_to_do:
                 ready_queue.put(pos)
     else:
-        tiles_to_process = []
+        tiles_to_process = set()
         for tile in generate_tiles_filtered(
             first_level_to_do, tile_filter, bottom_only=True
         ):
             ready_queue.put(tile.pos)
-            tiles_to_process.append(tile.pos)
+            tiles_to_process.add(tile.pos)
         _initiate_readiness_state(tiles_to_process, readiness)
 
     # The workers pick up tiles that are ready to process and do the merging.

--- a/toasty/merge.py
+++ b/toasty/merge.py
@@ -34,6 +34,7 @@ from tqdm import tqdm
 import warnings
 
 from . import pyramid
+from .pyramid import Pos
 from .image import Image
 
 
@@ -74,7 +75,9 @@ def averaging_merger(data):
         return np.nanmean(data.reshape(s), axis=(1, 3)).astype(data.dtype)
 
 
-def cascade_images(pio, start, merger, parallel=None, cli_progress=False):
+def cascade_images(
+    pio, start, merger, parallel=None, cli_progress=False, tile_filter=None
+):
     """Downsample image tiles all the way to the top of the pyramid.
 
     This function will walk the tiles in the tile pyramid, merging child tile
@@ -98,6 +101,9 @@ def cascade_images(pio, start, merger, parallel=None, cli_progress=False):
         forced. Pass ``1`` to force serial processing.
     cli_progress : optional boolean, defaults False
         If true, a progress bar will be printed to the terminal using tqdm.
+    tile_filter : callable
+        A tile filtering function, suitable for passing to
+        :func:`toasty.toast.generate_tiles_filtered`.
 
     """
     from .par_util import resolve_parallelism
@@ -108,12 +114,16 @@ def cascade_images(pio, start, merger, parallel=None, cli_progress=False):
         return  # Nothing to do.
 
     if parallel > 1:
-        _cascade_images_parallel(pio, start, merger, cli_progress, parallel)
+        _cascade_images_parallel(
+            pio, start, merger, cli_progress, parallel, tile_filter
+        )
     else:
-        _cascade_images_serial(pio, start, merger, cli_progress)
+        _cascade_images_serial(pio, start, merger, cli_progress, tile_filter)
 
 
-def _cascade_images_serial(pio, start, merger, cli_progress):
+def _cascade_images_serial(pio, start, merger, cli_progress, tile_filter=None):
+    from .toast import count_tiles_matching_filter, generate_tiles_filtered
+
     buf = None
 
     # Pyramids always follow a negative-parity (JPEG-like) coordinate system:
@@ -128,52 +138,65 @@ def _cascade_images_serial(pio, start, merger, cli_progress):
     else:
         slices = SLICES_MATCHING_PARITY
 
-    with tqdm(
-        total=pyramid.depth2tiles(start - 1), disable=not cli_progress
-    ) as progress:
-        for pos in pyramid.generate_pos(start):
-            if pos.n == start:
-                continue  # start layer is already there; we're cascading up
-
-            # By construction, the children of this tile have all already been
-            # processed.
-            children = pyramid.pos_children(pos)
-
-            img0 = pio.read_image(children[0], default="none")
-            img1 = pio.read_image(children[1], default="none")
-            img2 = pio.read_image(children[2], default="none")
-            img3 = pio.read_image(children[3], default="none")
-
-            if img0 is None and img1 is None and img2 is None and img3 is None:
+    if tile_filter is None:
+        total = pyramid.depth2tiles(start - 1)
+        with tqdm(total=total, disable=not cli_progress) as progress:
+            for pos in pyramid.generate_pos(
+                start - 1
+            ):  # start layer is already there; we're cascading up
+                _process_tile(pos, buf, pio, slices, merger)
                 progress.update(1)
-                continue  # No data here; ignore
-
-            if buf is not None:
-                buf.clear()
-
-            for slidx, subimg in zip(slices, (img0, img1, img2, img3)):
-                if subimg is not None:
-                    if buf is None:
-                        buf = subimg.mode.make_maskable_buffer(512, 512)
-                        buf.clear()
-
-                    subimg.update_into_maskable_buffer(
-                        buf,
-                        slice(None),
-                        slice(None),  # subimage indexer: nothing
-                        *slidx,  # buffer indexer: appropriate sub-quadrant
-                    )
-
-            merged = Image.from_array(merger(buf.asarray()))
-            min_value, max_value = _get_min_max_of_children(
-                pio, [img0, img1, img2, img3]
-            )
-
-            pio.write_image(pos, merged, min_value=min_value, max_value=max_value)
+    else:
+        # +1 because tile 0 is not counted by count_tiles_matching_filter
+        total = (
+            count_tiles_matching_filter(start - 1, tile_filter, bottom_only=False) + 1
+        )
+        with tqdm(total=total, disable=not cli_progress) as progress:
+            for tile in generate_tiles_filtered(
+                start - 1, tile_filter, bottom_only=False
+            ):
+                _process_tile(tile.pos, buf, pio, slices, merger)
+                progress.update(1)
+            _process_tile(Pos(0, 0, 0), buf, pio, slices, merger)
             progress.update(1)
 
     if cli_progress:
         print()
+
+
+def _process_tile(pos, buf, pio, slices, merger):
+    # By construction, the children of this tile have all already been
+    # processed.
+    children = pyramid.pos_children(pos)
+
+    img0 = pio.read_image(children[0], default="none")
+    img1 = pio.read_image(children[1], default="none")
+    img2 = pio.read_image(children[2], default="none")
+    img3 = pio.read_image(children[3], default="none")
+
+    if img0 is None and img1 is None and img2 is None and img3 is None:
+        return
+
+    if buf is not None:
+        buf.clear()
+
+    for slidx, subimg in zip(slices, (img0, img1, img2, img3)):
+        if subimg is not None:
+            if buf is None:
+                buf = subimg.mode.make_maskable_buffer(512, 512)
+                buf.clear()
+
+            subimg.update_into_maskable_buffer(
+                buf,
+                slice(None),
+                slice(None),  # subimage indexer: nothing
+                *slidx,  # buffer indexer: appropriate sub-quadrant
+            )
+
+    merged = Image.from_array(merger(buf.asarray()))
+    min_value, max_value = _get_min_max_of_children(pio, [img0, img1, img2, img3])
+
+    pio.write_image(pos, merged, min_value=min_value, max_value=max_value)
 
 
 def _get_min_max_of_children(pio, children):
@@ -205,7 +228,7 @@ def _get_existing_max_values(images):
     return values
 
 
-def _cascade_images_parallel(pio, start, merger, cli_progress, parallel):
+def _cascade_images_parallel(pio, start, merger, cli_progress, parallel, tile_filter):
     """Parallelized cascade operation
 
     At the moment, we require fork-based multiprocessing because the PyramidIO
@@ -217,13 +240,22 @@ def _cascade_images_parallel(pio, start, merger, cli_progress, parallel):
     import multiprocessing as mp
     from queue import Empty
     from .pyramid import Pos, pos_parent
+    from .toast import count_tiles_matching_filter, generate_tiles_filtered
 
     # The dispatcher process keeps track of finished tiles (reported in
     # `done_queue`) and notifiers worker when new tiles are ready to process
     # (`ready_queue`).
 
     first_level_to_do = start - 1
-    n_todo = pyramid.depth2tiles(first_level_to_do)
+    if tile_filter is None:
+        n_todo = pyramid.depth2tiles(first_level_to_do)
+    else:
+        n_todo = (
+            count_tiles_matching_filter(
+                first_level_to_do, tile_filter, bottom_only=False
+            )
+            + 1
+        )  # +1 because tile 0 is not counted by count_tiles_matching_filter
     ready_queue = mp.Queue()
     done_queue = mp.Queue(maxsize=2 * parallel)
     done_event = mp.Event()
@@ -233,10 +265,19 @@ def _cascade_images_parallel(pio, start, merger, cli_progress, parallel):
     # as possible, to make it easier to evaluate the output during processing ...
     # but in practice this isn't working. Seems that we're saturating the ready
     # queue before any higher-level tiles can become eligible for processing.
-
-    for pos in pyramid.generate_pos(first_level_to_do):
-        if pos.n == first_level_to_do:
-            ready_queue.put(pos)
+    readiness = {}
+    if tile_filter is None:
+        for pos in pyramid.generate_pos(first_level_to_do):
+            if pos.n == first_level_to_do:
+                ready_queue.put(pos)
+    else:
+        tiles_to_process = []
+        for tile in generate_tiles_filtered(
+            first_level_to_do, tile_filter, bottom_only=True
+        ):
+            ready_queue.put(tile.pos)
+            tiles_to_process.append(tile.pos)
+        _initiate_readiness_state(tiles_to_process, readiness)
 
     # The workers pick up tiles that are ready to process and do the merging.
 
@@ -252,8 +293,6 @@ def _cascade_images_parallel(pio, start, merger, cli_progress, parallel):
         workers.append(w)
 
     # Start dispatching tiles
-
-    readiness = {}
 
     with tqdm(total=n_todo, disable=not cli_progress) as progress:
         while True:
@@ -321,38 +360,30 @@ def _mp_cascade_worker(done_queue, ready_queue, done_event, pio, merger):
                 break
             continue
 
-        # By construction, the children of this tile have all already been
-        # processed.
-        children = pyramid.pos_children(pos)
-
-        img0 = pio.read_image(children[0], default="none")
-        img1 = pio.read_image(children[1], default="none")
-        img2 = pio.read_image(children[2], default="none")
-        img3 = pio.read_image(children[3], default="none")
-
-        if img0 is None and img1 is None and img2 is None and img3 is None:
-            pass  # No data here; ignore
-        else:
-            if buf is not None:
-                buf.clear()
-
-            for slidx, subimg in zip(slices, (img0, img1, img2, img3)):
-                if subimg is not None:
-                    if buf is None:
-                        buf = subimg.mode.make_maskable_buffer(512, 512)
-                        buf.clear()
-
-                    subimg.update_into_maskable_buffer(
-                        buf,
-                        slice(None),
-                        slice(None),  # subimage indexer: nothing
-                        *slidx,  # buffer indexer: appropriate sub-quadrant
-                    )
-
-            merged = Image.from_array(merger(buf.asarray()))
-            min_value, max_value = _get_min_max_of_children(
-                pio, [img0, img1, img2, img3]
-            )
-            pio.write_image(pos, merged, min_value=min_value, max_value=max_value)
+        _process_tile(pos, buf, pio, slices, merger)
 
         done_queue.put(pos)
+
+
+def _initiate_readiness_state(tiles_to_process, readiness):
+    """
+    Marking sibling tiles with no data (as well as their ancestors) as already processed.
+    This allows us to properly detect when ancestors of the tiles to be processed are
+    actually ready to be processed (i.e. when all children of a tile are marked as processed)
+    """
+    from .pyramid import pos_children, get_parents
+
+    if len(tiles_to_process) == 0 or Pos(0, 0, 0) in tiles_to_process:
+        return
+
+    parents = get_parents(tiles_to_process, get_all_ancestors=False)
+    for parent in parents:
+        for child in pos_children(parent):
+            if child not in tiles_to_process:
+                flags = readiness.get(parent, 0)
+                # Using the child's position within the parent tile (0-1x, 0-1y)
+                bit_num = 2 * (child.y % 2) + child.x % 2
+                flags |= 1 << bit_num
+                readiness[parent] = flags
+
+    _initiate_readiness_state(parents, readiness)

--- a/toasty/pyramid.py
+++ b/toasty/pyramid.py
@@ -209,7 +209,7 @@ def get_parents(pos_collection, get_all_ancestors=False):
     return parents
 
 
-def guess_base_layer_level(wcs, cli_progress=False):
+def guess_base_layer_level(wcs):
     from astropy import units as u
     from astropy.wcs.utils import proj_plane_pixel_area
     import math
@@ -233,13 +233,6 @@ def guess_base_layer_level(wcs, cli_progress=False):
     while tile_size_per_pixel > side_length:
         level += 1
         tile_size_per_pixel /= 2
-
-    if cli_progress:
-        print(
-            "Assuming level {} (~{} arcmin/pixel) is appropriate".format(
-                level, tile_arcmin_per_pixel / math.pow(2, level - 1)
-            )
-        )
 
     return level
 

--- a/toasty/pyramid.py
+++ b/toasty/pyramid.py
@@ -59,7 +59,7 @@ def tiles_at_depth(depth):
     """
     Return the number of tiles in the WWT tile pyramid layer at depth *depth*.
     """
-    return 4 ** depth
+    return 4**depth
 
 
 def is_subtile(deeper_pos, shallower_pos):
@@ -409,8 +409,8 @@ class PyramidIO(object):
         work. The "cascade" stage doesn't need locking, so in general only the
         deepest level of the pyramid will need to be cleaned.
         """
-        for x in range(0, 2 ** level):
-            for y in range(0, 2 ** level):
+        for x in range(0, 2**level):
+            for y in range(0, 2**level):
                 pos = Pos(level, x, y)
                 p = self.tile_path(pos, makedirs=False) + ".lock"
 

--- a/toasty/pyramid.py
+++ b/toasty/pyramid.py
@@ -21,6 +21,8 @@ next_highest_power_of_2
 Pos
 pos_children
 pos_parent
+get_parents
+guess_base_layer_level
 PyramidIO
 tiles_at_depth
 """.split()

--- a/toasty/samplers.py
+++ b/toasty/samplers.py
@@ -587,7 +587,7 @@ class WcsSampler(object):
             if e < nm:
                 # "top" edge (thinking of array as [lon, lat] ~ [x, y])
                 lo = max(e - 1, 0)
-                hi = max(e + 1, nm)
+                hi = min(e + 1, nm)
                 n = max(int(np.ceil(coarse_idx1[hi] - coarse_idx1[lo])), 1)
                 refined_idx1 = np.linspace(coarse_idx1[lo], coarse_idx1[hi], n)
                 refined_idx2 = np.zeros(n) + coarse_idx2[0]
@@ -595,7 +595,7 @@ class WcsSampler(object):
                 # "right" edge
                 rel = e - nm
                 lo = max(rel - 1, 0)
-                hi = max(rel + 1, nm)
+                hi = min(rel + 1, nm)
                 n = max(int(np.ceil(coarse_idx2[hi] - coarse_idx2[lo])), 1)
                 refined_idx1 = np.zeros(n) + coarse_idx1[nm]
                 refined_idx2 = np.linspace(coarse_idx2[lo], coarse_idx2[hi], n)
@@ -603,7 +603,7 @@ class WcsSampler(object):
                 # "bottom" edge, traversed backwards (right-to-left)
                 rel = 3 * nm - (1 + e)
                 lo = max(rel - 1, 0)
-                hi = max(rel + 1, nm)
+                hi = min(rel + 1, nm)
                 n = max(int(np.ceil(coarse_idx1[hi] - coarse_idx1[lo])), 1)
                 refined_idx1 = np.linspace(coarse_idx1[lo], coarse_idx1[hi], n)
                 refined_idx2 = np.zeros(n) + coarse_idx2[nm]
@@ -612,7 +612,7 @@ class WcsSampler(object):
                 # has an extra pixel to close back to [0,0].
                 rel = 4 * nm - e
                 lo = max(rel - 1, 0)
-                hi = max(rel + 1, nm)
+                hi = min(rel + 1, nm)
                 n = max(int(np.ceil(coarse_idx2[hi] - coarse_idx2[lo])), 1)
                 refined_idx1 = np.zeros(n) + coarse_idx1[0]
                 refined_idx2 = np.linspace(coarse_idx2[lo], coarse_idx2[hi], n)

--- a/toasty/samplers.py
+++ b/toasty/samplers.py
@@ -31,6 +31,7 @@ plate_carree_planet_zeroleft_sampler
 plate_carree_zeroright_sampler
 healpix_fits_file_sampler
 healpix_sampler
+WcsSampler
 """.split()
 
 import numpy as np
@@ -445,10 +446,9 @@ class WcsSampler(object):
 
     Returns
     -------
-    A function that samples the data; the call signature is ``vec2pix(lon, lat)
-    -> data``, where the inputs and output are 2D arrays and *lon* and *lat* are
-    in radians.
-
+    A function that samples the data; the call signature is
+    ``vec2pix(lon, lat)-> data``, where the inputs and output are 2D arrays
+    and *lon* and *lat* are in radians.
     """
 
     def __init__(self, data, wcs):
@@ -507,7 +507,7 @@ class WcsSampler(object):
                         samp.dtype
                     )
                 )
-            print(bad)
+
             samp[bad] = np.nan
 
             return samp

--- a/toasty/samplers.py
+++ b/toasty/samplers.py
@@ -691,7 +691,7 @@ class WcsSampler(object):
         return vec2pix
 
 
-def _latlon_tile_filter(image_lon_min1, image_lon_max1, image_lat_min1, image_lat_max1):
+def _latlon_tile_filter(image_lon_min, image_lon_max, image_lat_min, image_lat_max):
     """
     Return a "tile filter" function that only accepts tiles that overlap a
     bounding box in latitude and longitude.
@@ -710,19 +710,13 @@ def _latlon_tile_filter(image_lon_min1, image_lon_max1, image_lat_min1, image_la
     Usual bounding box semantics apply. If your bounding box is "too big" the
     only problem is that more tiles are touched than strictly necessary.
     """
+    assert image_lon_min < image_lon_max
+    assert image_lat_min < image_lat_max
 
     def latlon_tile_filter(tile):
         """
         Return true if this tile might contain data from the source image.
         """
-        assert image_lon_min1 < image_lon_max1
-        assert image_lat_min1 < image_lat_max1
-
-        # Need to copy the outer arguments since we're going to modify them.
-        image_lon_min = image_lon_min1
-        image_lon_max = image_lon_max1
-        image_lat_min = image_lat_min1
-        image_lat_max = image_lat_max1
 
         corner_lonlats = np.asarray(tile.corners)  # shape (4, 2)
 

--- a/toasty/samplers.py
+++ b/toasty/samplers.py
@@ -36,6 +36,9 @@ WcsSampler
 
 import numpy as np
 
+TWOPI = 2 * np.pi
+HALFPI = 0.5 * np.pi
+
 
 def healpix_sampler(data, nest=False, coord="C", interpolation="nearest"):
     """Create a sampler for HEALPix image data.
@@ -187,13 +190,13 @@ def plate_carree_sampler(data):
     data = np.asarray(data)
     ny, nx = data.shape[:2]
 
-    dx = nx / (2 * np.pi)  # pixels per radian in the X direction
+    dx = nx / TWOPI  # pixels per radian in the X direction
     dy = ny / np.pi  # ditto, for the Y direction
     lon0 = np.pi - 0.5 / dx  # longitudes of the centers of the pixels with ix = 0
-    lat0 = 0.5 * np.pi - 0.5 / dy  # latitudes of the centers of the pixels with iy = 0
+    lat0 = HALFPI - 0.5 / dy  # latitudes of the centers of the pixels with iy = 0
 
     def vec2pix(lon, lat):
-        lon = (lon + np.pi) % (2 * np.pi) - np.pi  # ensure in range [-pi, pi]
+        lon = (lon + np.pi) % TWOPI - np.pi  # ensure in range [-pi, pi]
         ix = (lon0 - lon) * dx
         ix = np.round(ix).astype(int)
         ix = np.clip(ix, 0, nx - 1)
@@ -230,16 +233,16 @@ def plate_carree_galactic_sampler(data):
     data = np.asarray(data)
     ny, nx = data.shape[:2]
 
-    dx = nx / (2 * np.pi)  # pixels per radian in the X direction
+    dx = nx / TWOPI  # pixels per radian in the X direction
     dy = ny / np.pi  # ditto, for the Y direction
     lon0 = np.pi - 0.5 / dx  # longitudes of the centers of the pixels with ix = 0
-    lat0 = 0.5 * np.pi - 0.5 / dy  # latitudes of the centers of the pixels with iy = 0
+    lat0 = HALFPI - 0.5 / dy  # latitudes of the centers of the pixels with iy = 0
 
     def vec2pix(lon, lat):
         gal = ICRS(lon * u.rad, lat * u.rad).transform_to(Galactic)
         lon, lat = gal.l.rad, gal.b.rad
 
-        lon = (lon + np.pi) % (2 * np.pi) - np.pi  # ensure in range [-pi, pi]
+        lon = (lon + np.pi) % TWOPI - np.pi  # ensure in range [-pi, pi]
         ix = (lon0 - lon) * dx
         ix = np.round(ix).astype(int)
         ix = np.clip(ix, 0, nx - 1)
@@ -276,15 +279,15 @@ def plate_carree_ecliptic_sampler(data):
     data = np.asarray(data)
     ny, nx = data.shape[:2]
 
-    dx = nx / (2 * np.pi)  # pixels per radian in the X direction
+    dx = nx / TWOPI  # pixels per radian in the X direction
     dy = ny / np.pi  # ditto, for the Y direction
     lon0 = np.pi - 0.5 / dx  # longitudes of the centers of the pixels with ix = 0
-    lat0 = 0.5 * np.pi - 0.5 / dy  # latitudes of the centers of the pixels with iy = 0
+    lat0 = HALFPI - 0.5 / dy  # latitudes of the centers of the pixels with iy = 0
 
     def vec2pix(lon, lat):
         ecl = ICRS(lon * u.rad, lat * u.rad).transform_to(Ecliptic)
         lon, lat = ecl.lon.rad, ecl.lat.rad
-        lon = lon % (2 * np.pi) - np.pi  # ensure in range [-pi, pi]
+        lon = lon % TWOPI - np.pi  # ensure in range [-pi, pi]
 
         ix = (lon0 - lon) * dx
         ix = np.round(ix).astype(int)
@@ -323,13 +326,13 @@ def plate_carree_planet_sampler(data):
     data = np.asarray(data)
     ny, nx = data.shape[:2]
 
-    dx = nx / (2 * np.pi)  # pixels per radian in the X direction
+    dx = nx / TWOPI  # pixels per radian in the X direction
     dy = ny / np.pi  # ditto, for the Y direction
     lon0 = -np.pi + 0.5 / dx  # longitudes of the centers of the pixels with ix = 0
-    lat0 = 0.5 * np.pi - 0.5 / dy  # latitudes of the centers of the pixels with iy = 0
+    lat0 = HALFPI - 0.5 / dy  # latitudes of the centers of the pixels with iy = 0
 
     def vec2pix(lon, lat):
-        lon = (lon + np.pi) % (2 * np.pi) - np.pi  # ensure in range [-pi, pi]
+        lon = (lon + np.pi) % TWOPI - np.pi  # ensure in range [-pi, pi]
         ix = (lon - lon0) * dx
         ix = np.round(ix).astype(int)
         ix = np.clip(ix, 0, nx - 1)
@@ -369,13 +372,13 @@ def plate_carree_planet_zeroleft_sampler(data):
     data = np.asarray(data)
     ny, nx = data.shape[:2]
 
-    dx = nx / (2 * np.pi)  # pixels per radian in the X direction
+    dx = nx / TWOPI  # pixels per radian in the X direction
     dy = ny / np.pi  # ditto, for the Y direction
     lon0 = 0.5 / dx  # longitudes of the centers of the pixels with ix = 0
-    lat0 = 0.5 * np.pi - 0.5 / dy  # latitudes of the centers of the pixels with iy = 0
+    lat0 = HALFPI - 0.5 / dy  # latitudes of the centers of the pixels with iy = 0
 
     def vec2pix(lon, lat):
-        lon = lon % (2 * np.pi)  # ensure in range [0, 2pi]
+        lon = lon % TWOPI  # ensure in range [0, 2pi]
         ix = (lon - lon0) * dx
         ix = np.round(ix).astype(int)
         ix = np.clip(ix, 0, nx - 1)
@@ -412,13 +415,13 @@ def plate_carree_zeroright_sampler(data):
     data = np.asarray(data)
     ny, nx = data.shape[:2]
 
-    dx = nx / (2 * np.pi)  # pixels per radian in the X direction
+    dx = nx / TWOPI  # pixels per radian in the X direction
     dy = ny / np.pi  # ditto, for the Y direction
-    lon0 = 2 * np.pi - 0.5 / dx  # longitudes of the centers of the pixels with ix = 0
-    lat0 = 0.5 * np.pi - 0.5 / dy  # latitudes of the centers of the pixels with iy = 0
+    lon0 = TWOPI - 0.5 / dx  # longitudes of the centers of the pixels with ix = 0
+    lat0 = HALFPI - 0.5 / dy  # latitudes of the centers of the pixels with iy = 0
 
     def vec2pix(lon, lat):
-        lon = lon % (2 * np.pi)  # ensure in range [0, 2pi]
+        lon = lon % TWOPI  # ensure in range [0, 2pi]
         ix = (lon0 - lon) * dx
         ix = np.round(ix).astype(int)
         ix = np.clip(ix, 0, nx - 1)
@@ -698,8 +701,8 @@ def _latlon_tile_filter(image_lon_min1, image_lon_max1, image_lat_min1, image_la
     this filtering process can be useful even if you don't have an actual image
     handy.
 
-    The image longitudes should be "unwrapped" such that ``image_lon_min1 <
-    image_lon_max1`` always. For instance, longitude bounds of ``(170, 400)``
+    The image longitudes should be "unwrapped" such that ``image_lon_min <
+    image_lon_max`` always. For instance, longitude bounds of ``(170, 400)``
     define an image that spans 230 degrees in longitude. The longitude bounds
     can span more than 360 degrees if the image really covers all longitudes.
     (This can happen if it touches one of the poles.)
@@ -762,7 +765,7 @@ def _latlon_tile_filter(image_lon_min1, image_lon_max1, image_lat_min1, image_la
 
             if tile_lon_max - tile_lon_min > np.pi:
                 keep_going = True
-                lons[imin] += 2 * np.pi
+                lons[imin] += TWOPI
 
         # Step 3: Now, shuffle the tile longitudes so that the left edge of the
         # tile is to the right of the left edge of the image. We might drag it
@@ -770,12 +773,12 @@ def _latlon_tile_filter(image_lon_min1, image_lon_max1, image_lat_min1, image_la
         # right.
 
         while tile_lon_min < image_lon_min:
-            tile_lon_min += 2 * np.pi
-            tile_lon_max += 2 * np.pi
+            tile_lon_min += TWOPI
+            tile_lon_max += TWOPI
 
-        while tile_lon_min - image_lon_min > 2 * np.pi:
-            tile_lon_min -= 2 * np.pi
-            tile_lon_max -= 2 * np.pi
+        while tile_lon_min - image_lon_min > TWOPI:
+            tile_lon_min -= TWOPI
+            tile_lon_max -= TWOPI
 
         # Step 4. Now we can test. In this configuration, if the left edge of
         # the tile is not clear of the right edge of the image, there's an
@@ -788,7 +791,7 @@ def _latlon_tile_filter(image_lon_min1, image_lon_max1, image_lat_min1, image_la
         # duplicated at its current position + 2pi radians, if the right edge of
         # the tile passes the "next" left edge of the image, we also overlap.
 
-        if tile_lon_max > image_lon_min + 2 * np.pi:
+        if tile_lon_max > image_lon_min + TWOPI:
             return True
 
         # Otherwise, there is no overlap.
@@ -821,7 +824,7 @@ class ChunkedPlateCarreeSampler(object):
 
         assert planetary, "XXX non-planetary plate carree not implemented"
 
-        self.sx = 2 * np.pi / self._image.shape[1]  # radians per pixel, X direction
+        self.sx = TWOPI / self._image.shape[1]  # radians per pixel, X direction
         self.sy = np.pi / self._image.shape[0]  # ditto, for the Y direction
 
     @property
@@ -835,8 +838,8 @@ class ChunkedPlateCarreeSampler(object):
         # pixel edges, in the appropriate direction, not pixel centers.
         lon_l = self.sx * cx - np.pi
         lon_r = self.sx * (cx + cw) - np.pi
-        lat_u = 0.5 * np.pi - self.sy * cy
-        lat_d = 0.5 * np.pi - self.sy * (cy + ch)  # note: lat_u > lat_d
+        lat_u = HALFPI - self.sy * cy
+        lat_d = HALFPI - self.sy * (cy + ch)  # note: lat_u > lat_d
 
         return lon_l, lon_r, lat_d, lat_u
 
@@ -895,7 +898,7 @@ class ChunkedPlateCarreeSampler(object):
         )  # latitudes of the centers of the pixels with iy = 0
 
         def plate_carree_planet_sampler(lon, lat):
-            lon = (lon + np.pi) % (2 * np.pi) - np.pi  # ensure in range [-pi, pi]
+            lon = (lon + np.pi) % TWOPI - np.pi  # ensure in range [-pi, pi]
             ix = (lon - lon0) * dx
             ix = np.round(ix).astype(int)
             ok = (ix >= 0) & (ix < nx)

--- a/toasty/tests/test_merge.py
+++ b/toasty/tests/test_merge.py
@@ -16,16 +16,18 @@ def test_averaging_merger():
     from ..merge import averaging_merger
 
     t = np.array([[np.nan, 1], [3, np.nan]])
-    nt.assert_almost_equal(averaging_merger(t), [[2.]])
+    nt.assert_almost_equal(averaging_merger(t), [[2.0]])
 
 
 class TestCascade(object):
     def setup_method(self, method):
         from tempfile import mkdtemp
+
         self.work_dir = mkdtemp()
 
     def teardown_method(self, method):
         from shutil import rmtree
+
         rmtree(self.work_dir)
 
     def work_path(self, *pieces):
@@ -37,21 +39,27 @@ class TestCascade(object):
         module directly.
 
         """
-        for variants in (['--parallelism=1'], ['--parallelism=2', '--placeholder-thumbnail']):
-            args = ['tile-allsky']
+        for variants in (
+            ["--parallelism=1"],
+            ["--parallelism=2", "--placeholder-thumbnail"],
+        ):
+            args = ["tile-allsky"]
             args += variants
             args += [
-                '--outdir', self.work_path('basic_cli'),
-                test_path('Equirectangular_projection_SW-tweaked.jpg'),
-                '1',
+                "--outdir",
+                self.work_path("basic_cli"),
+                test_path("Equirectangular_projection_SW-tweaked.jpg"),
+                "1",
             ]
             cli.entrypoint(args)
 
-        for parallelism in '12':
+        for parallelism in "12":
             args = [
-                'cascade',
-                '--parallelism', parallelism,
-                '--start', '1',
-                self.work_path('basic_cli'),
+                "cascade",
+                "--parallelism",
+                parallelism,
+                "--start",
+                "1",
+                self.work_path("basic_cli"),
             ]
             cli.entrypoint(args)

--- a/toasty/tests/test_merge.py
+++ b/toasty/tests/test_merge.py
@@ -19,6 +19,23 @@ def test_averaging_merger():
     nt.assert_almost_equal(averaging_merger(t), [[2.0]])
 
 
+def test_initiate_readiness_state():
+    from ..merge import _initiate_readiness_state
+    from ..pyramid import Pos
+
+    readiness_state = {}
+    _initiate_readiness_state({Pos(1, 0, 0), Pos(1, 1, 0)}, readiness_state)
+    assert readiness_state.get(Pos(n=0, x=0, y=0)) == 0b1100
+
+    readiness_state = {}
+    _initiate_readiness_state({Pos(3, 7, 7), Pos(3, 3, 1)}, readiness_state)
+    assert readiness_state.get(Pos(n=0, x=0, y=0)) == 0b0110
+    assert readiness_state.get(Pos(n=1, x=1, y=1)) == 0b0111
+    assert readiness_state.get(Pos(n=1, x=0, y=0)) == 0b1101
+    assert readiness_state.get(Pos(n=2, x=3, y=3)) == 0b0111
+    assert readiness_state.get(Pos(n=2, x=1, y=0)) == 0b0111
+
+
 class TestCascade(object):
     def setup_method(self, method):
         from tempfile import mkdtemp

--- a/toasty/tests/test_pyramid.py
+++ b/toasty/tests/test_pyramid.py
@@ -40,6 +40,34 @@ def test_pos_parent():
         pos_parent(Pos(0, 0, 0))
 
 
+def test_get_parents():
+    from ..pyramid import get_parents
+
+    assert get_parents((Pos(1, 0, 0), Pos(1, 1, 0))) == {Pos(0, 0, 0)}
+
+    all_ancestors = {
+        Pos(n=0, x=0, y=0),
+        Pos(n=1, x=0, y=0),
+        Pos(n=1, x=1, y=0),
+        Pos(n=2, x=1, y=1),
+        Pos(n=2, x=2, y=1),
+        Pos(n=3, x=3, y=2),
+        Pos(n=3, x=4, y=2),
+        Pos(n=4, x=7, y=4),
+        Pos(n=4, x=8, y=4),
+        Pos(n=5, x=15, y=8),
+        Pos(n=5, x=16, y=8),
+        Pos(n=6, x=31, y=16),
+        Pos(n=6, x=32, y=16),
+    }
+    assert (
+        get_parents(
+            {Pos(7, 63, 33), Pos(7, 64, 33), Pos(7, 65, 33)}, get_all_ancestors=True
+        )
+        == all_ancestors
+    )
+
+
 def test_generate_pos():
     from ..pyramid import generate_pos
 
@@ -52,3 +80,29 @@ def test_generate_pos():
         Pos(1, 1, 1),
         Pos(0, 0, 0),
     ]
+
+
+def test_guess_base_layer_level():
+    from ..pyramid import guess_base_layer_level
+    from astropy.wcs import WCS
+
+    wcs = WCS()
+    wcs.wcs.ctype = "RA---GLS", "DEC--GLS"
+    wcs.wcs.crval = 0, 0
+    wcs.wcs.crpix = 1, 1
+    wcs._naxis = [1, 1]
+
+    wcs.wcs.cdelt = 0.36, 0.36
+    assert guess_base_layer_level(wcs=wcs) == 1
+
+    wcs.wcs.cdelt = 0.35, 0.35
+    assert guess_base_layer_level(wcs=wcs) == 2
+
+    wcs.wcs.cdelt = 0.15, 0.15
+    assert guess_base_layer_level(wcs=wcs) == 3
+
+    wcs.wcs.cdelt = 0.005, 0.005
+    assert guess_base_layer_level(wcs=wcs) == 8
+
+    wcs.wcs.cdelt = 0.0001, 0.0001
+    assert guess_base_layer_level(wcs=wcs) == 13

--- a/toasty/tests/test_toasty.py
+++ b/toasty/tests/test_toasty.py
@@ -74,7 +74,7 @@ class TestToasty(object):
             override=True,
         )
         assert bld.imgset.projection == ProjectionType.TOAST
-        assert out_dir == test_path("wcs512_tiled")
+        assert out_dir == test_path("wcs512_tiled_TOAST")
         assert Path(out_dir, "index_rel.wtml").is_file()
         assert Path(out_dir, "0", "0", "0_0.fits").is_file()
         rmtree(out_dir)

--- a/toasty/tests/test_toasty.py
+++ b/toasty/tests/test_toasty.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 from . import test_path
-from ..__init__ import TilingMethod, tile_fits
+from .. import TilingMethod, tile_fits
 from wwt_data_formats.enums import ProjectionType
 from shutil import rmtree
 from pathlib import Path

--- a/toasty/tests/test_toasty.py
+++ b/toasty/tests/test_toasty.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function
 import pytest
 from . import test_path
 from ..__init__ import TilingMethod, tile_fits
+from wwt_data_formats.enums import ProjectionType
 from shutil import rmtree
 from pathlib import Path
 
@@ -27,7 +28,10 @@ class TestToasty(object):
             out_dir=out_dir_input,
             tiling_method=TilingMethod.TAN,
             cli_progress=True,
+            override=True,
         )
+        # source image is smaller than one tile (256x256),so it is conveted to a sky image
+        assert bld.imgset.projection == ProjectionType.SKY_IMAGE
         assert out_dir == out_dir_input
         assert Path(out_dir, "index_rel.wtml").is_file()
         assert Path(out_dir, "0", "0", "0_0.fits").is_file()
@@ -38,7 +42,10 @@ class TestToasty(object):
         # collections take a significant time to process
         out_dir, bld = tile_fits(
             fits=[test_path("wcs512.fits.gz"), test_path("wcs512.fits.gz")],
+            tiling_method=TilingMethod.TAN,
+            override=True,
         )
+        assert bld.imgset.projection == ProjectionType.TAN
         assert out_dir == test_path("wcs512_tiled")
         assert Path(out_dir, "index_rel.wtml").is_file()
         assert Path(out_dir, "0", "0", "0_0.fits").is_file()
@@ -52,7 +59,9 @@ class TestToasty(object):
             out_dir=out_dir_input,
             tiling_method=TilingMethod.TOAST,
             cli_progress=True,
+            override=True,
         )
+        assert bld.imgset.projection == ProjectionType.TOAST
         assert out_dir == out_dir_input
         assert Path(out_dir, "index_rel.wtml").is_file()
         assert Path(out_dir, "0", "0", "0_0.fits").is_file()
@@ -61,7 +70,10 @@ class TestToasty(object):
 
         out_dir, bld = tile_fits(
             fits=[test_path("wcs512.fits.gz")],
+            tiling_method=TilingMethod.TOAST,
+            override=True,
         )
+        assert bld.imgset.projection == ProjectionType.TOAST
         assert out_dir == test_path("wcs512_tiled")
         assert Path(out_dir, "index_rel.wtml").is_file()
         assert Path(out_dir, "0", "0", "0_0.fits").is_file()

--- a/toasty/tests/test_toasty.py
+++ b/toasty/tests/test_toasty.py
@@ -6,38 +6,63 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 from . import test_path
-from ..__init__ import tile_fits
+from ..__init__ import TilingMethod, tile_fits
 from shutil import rmtree
 from pathlib import Path
 
 try:
     from astropy.io import fits
+
     HAS_ASTRO = True
 except ImportError:
     HAS_ASTRO = False
 
 
 class TestToasty(object):
-
-    @pytest.mark.skipif('not HAS_ASTRO')
-    def test_tile_fits(self):
-        out_dir_input = 'test_tiled'
+    @pytest.mark.skipif("not HAS_ASTRO")
+    def test_tile_fits_tan(self):
+        out_dir_input = "test_tiled"
         out_dir, bld = tile_fits(
-            fits=test_path('herschel_spire.fits.gz'),
+            fits=test_path("herschel_spire.fits.gz"),
             out_dir=out_dir_input,
-            cli_progress=True)
+            tiling_method=TilingMethod.TAN,
+            cli_progress=True,
+        )
         assert out_dir == out_dir_input
-        assert Path(out_dir, 'index_rel.wtml').is_file()
-        assert Path(out_dir, '0', '0', '0_0.fits').is_file()
-        assert bld.imgset.url == '{1}/{3}/{3}_{2}.fits'
+        assert Path(out_dir, "index_rel.wtml").is_file()
+        assert Path(out_dir, "0", "0", "0_0.fits").is_file()
+        assert bld.imgset.url == "{1}/{3}/{3}_{2}.fits"
         rmtree(out_dir)
 
         # Only testing with a multi tan collection, since multi WCS
         # collections take a significant time to process
         out_dir, bld = tile_fits(
-            fits=[test_path('wcs512.fits.gz'), test_path('wcs512.fits.gz')],
+            fits=[test_path("wcs512.fits.gz"), test_path("wcs512.fits.gz")],
         )
-        assert out_dir == test_path('wcs512_tiled')
-        assert Path(out_dir, 'index_rel.wtml').is_file()
-        assert Path(out_dir, '0', '0', '0_0.fits').is_file()
+        assert out_dir == test_path("wcs512_tiled")
+        assert Path(out_dir, "index_rel.wtml").is_file()
+        assert Path(out_dir, "0", "0", "0_0.fits").is_file()
+        rmtree(out_dir)
+
+    @pytest.mark.skipif("not HAS_ASTRO")
+    def test_tile_fits_toast(self):
+        out_dir_input = "test_tiled"
+        out_dir, bld = tile_fits(
+            fits=test_path("herschel_spire.fits.gz"),
+            out_dir=out_dir_input,
+            tiling_method=TilingMethod.TOAST,
+            cli_progress=True,
+        )
+        assert out_dir == out_dir_input
+        assert Path(out_dir, "index_rel.wtml").is_file()
+        assert Path(out_dir, "0", "0", "0_0.fits").is_file()
+        assert bld.imgset.url == "{1}/{3}/{3}_{2}.fits"
+        rmtree(out_dir)
+
+        out_dir, bld = tile_fits(
+            fits=[test_path("wcs512.fits.gz")],
+        )
+        assert out_dir == test_path("wcs512_tiled")
+        assert Path(out_dir, "index_rel.wtml").is_file()
+        assert Path(out_dir, "0", "0", "0_0.fits").is_file()
         rmtree(out_dir)


### PR DESCRIPTION
Mostly addresses https://github.com/WorldWideTelescope/toasty/issues/81, but does nothing about masked pixels and does not yet support a collection of FITS input. 

The main feature is based around the WCS sampler & filter, which allows us to create a TOAST imageset from any array/wcs input. The `tile_fits` method now has the ability to create TOAST imagesets, which also has replaced HiPS as the default tiling method for images covering a large area of the sky.

Upgrades to the general process:
1. `toast_base` does now accept tile filters to allow processing of a specific area, and skipping every tile outside input bounds
2. Same for the cascade process
3. Replaced the parameters `force_tan` etc. with a `TilingMethod` enum

Requires https://github.com/WorldWideTelescope/wwt_data_formats/pull/50 to work properly.