### PR TITLE
Tweaks based on DECaPS2 processing

### DIFF
--- a/docs/api/toasty.progress.progress_bar.rst
+++ b/docs/api/toasty.progress.progress_bar.rst
@@ -1,0 +1,6 @@
+progress_bar
+============
+
+.. currentmodule:: toasty.progress
+
+.. autofunction:: progress_bar

--- a/docs/api/toasty.progress.rst
+++ b/docs/api/toasty.progress.rst
@@ -1,0 +1,3 @@
+.. automodapi:: toasty.progress
+   :no-inheritance-diagram:
+   :no-inherited-members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,7 @@ Python API Reference
    api/toasty.pipeline.cli
    api/toasty.pipeline.djangoplicity
    api/toasty.pipeline.local_io
+   api/toasty.progress
    api/toasty.pyramid
    api/toasty.samplers
    api/toasty.study

--- a/toasty/image.py
+++ b/toasty/image.py
@@ -1153,6 +1153,24 @@ class Image(object):
                 f"unhandled mode `{self.mode}` in update_into_maskable_buffer"
             )
 
+    def is_completely_masked(self):
+        """
+        Return whether the image is completely masked.
+        """
+
+        i = self.asarray()
+
+        if self.mode in (ImageMode.RGB, ImageMode.U8, ImageMode.I16, ImageMode.I32):
+            return False
+        elif self.mode in (ImageMode.F32, ImageMode.F64, ImageMode.F16x3):
+            return np.all(np.isnan(i))
+        elif self.mode == ImageMode.RGBA:
+            return np.all(i[..., 3] == 0)
+        else:
+            raise Exception(
+                f"unhandled mode `{self.mode}` in is_completely_masked"
+            )
+
     def save(
         self, path_or_stream, format=None, mode=None, min_value=None, max_value=None
     ):

--- a/toasty/multi_wcs.py
+++ b/toasty/multi_wcs.py
@@ -13,9 +13,9 @@ This module has the following Python package dependencies:
 - shapely (to optimize the projection in reproject)
 """
 
-__all__ = '''
+__all__ = """
 MultiWcsProcessor
-'''.split()
+""".split()
 
 import numpy as np
 import warnings
@@ -25,6 +25,7 @@ from .progress import progress_bar
 from .study import StudyTiling
 
 MAXIMUM_CHUNK_SIZE = 128 * 1024 * 1024
+
 
 class MultiWcsDescriptor(object):
     ident = None
@@ -49,7 +50,6 @@ class MultiWcsProcessor(object):
     def __init__(self, collection):
         self._collection = collection
 
-
     def compute_global_pixelization(self, builder):
         from reproject.mosaicking.wcs_helpers import find_optimal_celestial_wcs
 
@@ -62,7 +62,9 @@ class MultiWcsProcessor(object):
             desc.in_wcs = coll_desc.wcs
             return desc
 
-        self._descs = [create_mwcs_descriptor(d) for d in self._collection.descriptions()]
+        self._descs = [
+            create_mwcs_descriptor(d) for d in self._collection.descriptions()
+        ]
 
         # Compute the optimal tangential tiling that fits all of them. Since WWT
         # tilings must be done in a negative-parity coordinate system, we use an
@@ -70,8 +72,8 @@ class MultiWcsProcessor(object):
 
         wcs, shape = find_optimal_celestial_wcs(
             ((desc.in_shape, desc.in_wcs) for desc in self._descs),
-            auto_rotate = True,
-            projection = 'TAN',
+            auto_rotate=True,
+            projection="TAN",
         )
 
         desc = ImageDescription(wcs=wcs, shape=shape)
@@ -101,10 +103,14 @@ class MultiWcsProcessor(object):
             ny, nx = desc.in_shape
             xc = np.array([-0.5, nx - 0.5, nx - 0.5, -0.5])
             yc = np.array([-0.5, -0.5, ny - 0.5, ny - 0.5])
-            xc_out, yc_out = self._combined_wcs.world_to_pixel(desc.in_wcs.pixel_to_world(xc, yc))
+            xc_out, yc_out = self._combined_wcs.world_to_pixel(
+                desc.in_wcs.pixel_to_world(xc, yc)
+            )
 
             if np.any(np.isnan(xc_out)) or np.any(np.isnan(yc_out)):
-                raise Exception(f'segment {desc.ident} does not fit within the global mosaic')
+                raise Exception(
+                    f"segment {desc.ident} does not fit within the global mosaic"
+                )
 
             desc.imin = max(0, int(np.floor(xc_out.min() + 0.5)))
             desc.imax = min(self._combined_shape[1], int(np.ceil(xc_out.max() + 0.5)))
@@ -115,7 +121,9 @@ class MultiWcsProcessor(object):
             height = desc.jmax - desc.jmin
 
             if width <= 0 or height <= 0:
-                raise Exception(f'segment {desc.ident} maps to zero size in the global mosaic')
+                raise Exception(
+                    f"segment {desc.ident} maps to zero size in the global mosaic"
+                )
 
             # Prepare to reproject the image onto the target pixelization.
             # Reproject isn't very memory efficient and can blow up with large
@@ -147,8 +155,9 @@ class MultiWcsProcessor(object):
 
         return self  # chaining convenience
 
-
-    def tile(self, pio, reproject_function, parallel=None, cli_progress=False, **kwargs):
+    def tile(
+        self, pio, reproject_function, parallel=None, cli_progress=False, **kwargs
+    ):
         """
         Tile!!!!
 
@@ -167,18 +176,21 @@ class MultiWcsProcessor(object):
         cli_progress : optional boolean, defaults False
             If true, a progress bar will be printed to the terminal.
         """
+
         from .par_util import resolve_parallelism
+
         parallel = resolve_parallelism(parallel)
 
         if parallel > 1:
-            self._tile_parallel(pio, reproject_function, cli_progress, parallel, **kwargs)
+            self._tile_parallel(
+                pio, reproject_function, cli_progress, parallel, **kwargs
+            )
         else:
             self._tile_serial(pio, reproject_function, cli_progress, **kwargs)
 
         # Since we used `pio.update_image()`, we should clean up the lockfiles
         # that were generated.
         pio.clean_lockfiles(self._tiling._tile_levels)
-
 
     def _tile_serial(self, pio, reproject_function, cli_progress, **kwargs):
         invert_into_tiles = pio.get_default_vertical_parity_sign() == 1
@@ -189,19 +201,29 @@ class MultiWcsProcessor(object):
 
                 for chunk in desc.chunks:
                     chunk_shape = (chunk.j1 - chunk.j0, desc.imax - desc.imin)
-                    chunk_wcs = self._combined_wcs[chunk.j0:chunk.j1, desc.imin:desc.imax]
+                    chunk_wcs = self._combined_wcs[
+                        chunk.j0 : chunk.j1, desc.imin : desc.imax
+                    ]
 
                     array = reproject_function(
                         (input_array, image.wcs),
                         output_projection=chunk_wcs,
                         shape_out=chunk_shape,
                         return_footprint=False,
-                        **kwargs
+                        **kwargs,
                     )
 
                     image_out = Image.from_array(array.astype(np.float32))
 
-                    for pos, width, height, image_x, image_y, tile_x, tile_y in chunk.sub_tiling.generate_populated_positions():
+                    for (
+                        pos,
+                        width,
+                        height,
+                        image_x,
+                        image_y,
+                        tile_x,
+                        tile_y,
+                    ) in chunk.sub_tiling.generate_populated_positions():
                         # Because we are doing an arbitrary WCS reprojection anyway,
                         # we can ensure that our source image is stored with a
                         # top-down vertical data layout, AKA negative image parity,
@@ -216,7 +238,9 @@ class MultiWcsProcessor(object):
                             flip_tile_y0 = flip_tile_y1 - height
 
                             if flip_tile_y0 == -1:
-                                flip_tile_y0 = None  # with a slice, -1 does the wrong thing
+                                flip_tile_y0 = (
+                                    None  # with a slice, -1 does the wrong thing
+                                )
 
                             by_idx = slice(flip_tile_y1, flip_tile_y0, -1)
                         else:
@@ -226,8 +250,12 @@ class MultiWcsProcessor(object):
                         ix_idx = slice(image_x, image_x + width)
                         bx_idx = slice(tile_x, tile_x + width)
 
-                        with pio.update_image(pos, masked_mode=image_out.mode, default='masked') as basis:
-                            image_out.update_into_maskable_buffer(basis, iy_idx, ix_idx, by_idx, bx_idx)
+                        with pio.update_image(
+                            pos, masked_mode=image_out.mode, default="masked"
+                        ) as basis:
+                            image_out.update_into_maskable_buffer(
+                                basis, iy_idx, ix_idx, by_idx, bx_idx
+                            )
 
                         progress.update(1)
 
@@ -237,11 +265,14 @@ class MultiWcsProcessor(object):
         # Start up the workers
 
         done_event = mp.Event()
-        queue = mp.Queue(maxsize = 2 * parallel)
+        queue = mp.Queue(maxsize=2 * parallel)
         workers = []
 
         for _ in range(parallel):
-            w = mp.Process(target=_mp_tile_worker, args=(queue, done_event, pio, reproject_function, kwargs))
+            w = mp.Process(
+                target=_mp_tile_worker,
+                args=(queue, done_event, pio, reproject_function, kwargs),
+            )
             w.daemon = True
             w.start()
             workers.append(w)
@@ -275,7 +306,7 @@ def _mp_tile_worker(queue, done_event, pio, reproject_function, kwargs):
         try:
             # un-pickling WCS objects always triggers warnings right now
             with warnings.catch_warnings():
-                warnings.simplefilter('ignore')
+                warnings.simplefilter("ignore")
                 image, desc, combined_wcs = queue.get(True, timeout=10)
         except Empty:
             if done_event.is_set():
@@ -286,19 +317,27 @@ def _mp_tile_worker(queue, done_event, pio, reproject_function, kwargs):
 
         for chunk in desc.chunks:
             chunk_shape = (chunk.j1 - chunk.j0, desc.imax - desc.imin)
-            chunk_wcs = combined_wcs[chunk.j0:chunk.j1, desc.imin:desc.imax]
+            chunk_wcs = combined_wcs[chunk.j0 : chunk.j1, desc.imin : desc.imax]
 
             array = reproject_function(
                 (input_array, image.wcs),
                 output_projection=chunk_wcs,
                 shape_out=chunk_shape,
                 return_footprint=False,
-                **kwargs
+                **kwargs,
             )
 
             image_out = Image.from_array(array.astype(np.float32))
 
-            for pos, width, height, image_x, image_y, tile_x, tile_y in chunk.sub_tiling.generate_populated_positions():
+            for (
+                pos,
+                width,
+                height,
+                image_x,
+                image_y,
+                tile_x,
+                tile_y,
+            ) in chunk.sub_tiling.generate_populated_positions():
                 if invert_into_tiles:
                     flip_tile_y1 = 255 - tile_y
                     flip_tile_y0 = flip_tile_y1 - height
@@ -314,5 +353,9 @@ def _mp_tile_worker(queue, done_event, pio, reproject_function, kwargs):
                 ix_idx = slice(image_x, image_x + width)
                 bx_idx = slice(tile_x, tile_x + width)
 
-                with pio.update_image(pos, masked_mode=image_out.mode, default='masked') as basis:
-                    image_out.update_into_maskable_buffer(basis, iy_idx, ix_idx, by_idx, bx_idx)
+                with pio.update_image(
+                    pos, masked_mode=image_out.mode, default="masked"
+                ) as basis:
+                    image_out.update_into_maskable_buffer(
+                        basis, iy_idx, ix_idx, by_idx, bx_idx
+                    )

--- a/toasty/progress.py
+++ b/toasty/progress.py
@@ -15,6 +15,7 @@ progress_bar
 """.split()
 
 from contextlib import contextmanager
+import os
 import sys
 
 from tqdm import tqdm
@@ -32,7 +33,9 @@ def progress_bar(total=None, show=None):
         disable=not show,
     )
 
-    if not sys.stdout.isatty():
+    log_like_output = not sys.stdout.isatty() and "JPY_PARENT_PID" not in os.environ
+
+    if log_like_output:
         args["bar_format"] = "{l_bar}{bar}{r_bar}\n"
         args["mininterval"] = NON_TTY_INTERVAL
         args["maxinterval"] = NON_TTY_INTERVAL
@@ -41,5 +44,5 @@ def progress_bar(total=None, show=None):
         with tqdm(**args) as progress:
             yield progress
     finally:
-        if show and sys.stdout.isatty():
+        if show and not log_like_output:
             print()

--- a/toasty/progress.py
+++ b/toasty/progress.py
@@ -1,0 +1,45 @@
+# -*- mode: python; coding: utf-8 -*-
+# Copyright 2022 the AAS WorldWide Telescope project
+# Licensed under the MIT License.
+
+"""Utilities for progress reporting
+
+This module provides an extremely thin wrapper around TQDM that avoids ``\r``
+output when stdout is not a terminal, for producing more easily greppable logs.
+It also reduces the update frequency to reduce log volume.
+
+"""
+
+__all__ = """
+progress_bar
+""".split()
+
+from contextlib import contextmanager
+import sys
+
+from tqdm import tqdm
+
+NON_TTY_INTERVAL = 30
+
+
+@contextmanager
+def progress_bar(total=None, show=None):
+    assert total is not None
+    assert show is not None
+
+    args = dict(
+        total=total,
+        disable=not show,
+    )
+
+    if not sys.stdout.isatty():
+        args["bar_format"] = "{l_bar}{bar}{r_bar}\n"
+        args["mininterval"] = NON_TTY_INTERVAL
+        args["maxinterval"] = NON_TTY_INTERVAL
+
+    try:
+        with tqdm(**args) as progress:
+            yield progress
+    finally:
+        if show and sys.stdout.isatty():
+            print()

--- a/toasty/progress.py
+++ b/toasty/progress.py
@@ -25,6 +25,31 @@ NON_TTY_INTERVAL = 30
 
 @contextmanager
 def progress_bar(total=None, show=None):
+    """Create and return a TQDM progress bar.
+
+    Parameters
+    ----------
+    total : int
+        The total number of items to be processed.
+    show : bool
+        Whether the progress bar should actually be shown.
+
+    Returns
+    -------
+    A ``tqdm`` progress bar instance.
+
+    Notes
+    -----
+    The progress bar will be customized to be emitted much less frequently when
+    standard output is not a terminal. It will also print newlines with every
+    update, which makes log files much easier to review.
+
+    Terminal-style output will be used even when standard output is not a
+    terminal, *if* the environment variable ``JPY_PARENT_PID`` is set. This
+    variable is set inside Jupyter kernel processes, and in those circumstances
+    stdout is a pipe but we probably still want to use the terminal-like
+    progress bar output."""
+
     assert total is not None
     assert show is not None
 

--- a/toasty/pyramid.py
+++ b/toasty/pyramid.py
@@ -429,13 +429,23 @@ class PyramidIO(object):
 
         """
         p = self.tile_path(pos, format=format or self._default_format)
-        image.save(
-            p,
-            format=format or self._default_format,
-            mode=mode,
-            min_value=min_value,
-            max_value=max_value,
-        )
+
+        if image.is_completely_masked():
+            # Fully masked tiles are not written to disk. If we're overwriting a
+            # tile pyramid, we can't just leave any existing file lying around;
+            # we must ensure that it is destroyed.
+            try:
+                os.unlink(p)
+            except (FileNotFoundError, OSError):
+                pass
+        else:
+            image.save(
+                p,
+                format=format or self._default_format,
+                mode=mode,
+                min_value=min_value,
+                max_value=max_value,
+            )
 
     @contextmanager
     def update_image(self, pos, default="none", masked_mode=None, format=None):

--- a/toasty/study.py
+++ b/toasty/study.py
@@ -1,12 +1,11 @@
 # -*- mode: python; coding: utf-8 -*-
-# Copyright 2021 the AAS WorldWide Telescope project
+# Copyright 2021-2022 the AAS WorldWide Telescope project
 # Licensed under the MIT License.
 
 """Common routines for tiling images anchored to the sky in a gnomonic
 (tangential) projection.
 
 """
-from __future__ import absolute_import, division, print_function
 
 __all__ = '''
 StudyTiling
@@ -14,9 +13,9 @@ tile_study_image
 '''.split()
 
 import numpy as np
-from tqdm import tqdm
 
-from .pyramid import Pos, next_highest_power_of_2, tiles_at_depth
+from .progress import progress_bar
+from .pyramid import Pos, next_highest_power_of_2
 
 
 class StudyTiling(object):
@@ -308,7 +307,7 @@ class StudyTiling(object):
         pio : :class:`toasty.pyramid.PyramidIO`
             A handle for doing I/O on the tile pyramid
         cli_progress : optional boolean, defaults False
-            If true, a progress bar will be printed to the terminal using tqdm.
+            If true, a progress bar will be printed to the terminal.
 
         Returns
         -------
@@ -332,8 +331,18 @@ class StudyTiling(object):
         buffer = image.mode.make_maskable_buffer(256, 256)
         buffer._default_format = image._default_format
 
-        with tqdm(total=self.count_populated_positions(), disable=not cli_progress) as progress:
-            for pos, width, height, image_x, image_y, tile_x, tile_y in self.generate_populated_positions():
+        with progress_bar(
+            total=self.count_populated_positions(), show=cli_progress
+        ) as progress:
+            for (
+                pos,
+                width,
+                height,
+                image_x,
+                image_y,
+                tile_x,
+                tile_y,
+            ) in self.generate_populated_positions():
                 if invert_into_tiles:
                     flip_tile_y1 = 255 - tile_y
                     flip_tile_y0 = flip_tile_y1 - height
@@ -353,9 +362,6 @@ class StudyTiling(object):
                 pio.write_image(pos, buffer)
                 progress.update(1)
 
-        if cli_progress:
-            print()
-
         return self
 
 
@@ -369,7 +375,7 @@ def tile_study_image(image, pio, cli_progress=False):
     pio : :class:`toasty.pyramid.PyramidIO`
         A handle for doing I/O on the tile pyramid
     cli_progress : optional boolean, defaults False
-        If true, a progress bar will be printed to the terminal using tqdm.
+        If true, a progress bar will be printed to the terminal.
 
     Returns
     -------

--- a/toasty/study.py
+++ b/toasty/study.py
@@ -7,10 +7,10 @@
 
 """
 
-__all__ = '''
+__all__ = """
 StudyTiling
 tile_study_image
-'''.split()
+""".split()
 
 import numpy as np
 
@@ -31,6 +31,7 @@ class StudyTiling(object):
     functionality doesn't need to care about that.
 
     """
+
     _width = None
     "The width of the region in which image data are available, in pixels (int)."
 
@@ -56,6 +57,7 @@ class StudyTiling(object):
     pixelization, in pixels down from the top edge (int). Nonnegative.
 
     """
+
     def __init__(self, width, height):
         """Set up the tiling information.
 
@@ -71,9 +73,9 @@ class StudyTiling(object):
         height = int(height)
 
         if width <= 0:
-            raise ValueError('bad width value: %r' % (width, ))
+            raise ValueError("bad width value: %r" % (width,))
         if height <= 0:
-            raise ValueError('bad height value: %r' % (height, ))
+            raise ValueError("bad height value: %r" % (height,))
 
         self._width = width
         self._height = height
@@ -84,7 +86,6 @@ class StudyTiling(object):
         self._tile_levels = int(np.log2(self._tile_size))
         self._img_gx0 = (self._p2n - self._width) // 2
         self._img_gy0 = (self._p2n - self._height) // 2
-
 
     def compute_for_subimage(self, subim_ix, subim_iy, subim_width, subim_height):
         """
@@ -113,13 +114,13 @@ class StudyTiling(object):
 
         """
         if subim_width < 0 or subim_width > self._width:
-            raise ValueError('bad subimage width value {!r}'.format(subim_width))
+            raise ValueError("bad subimage width value {!r}".format(subim_width))
         if subim_height < 0 or subim_height > self._height:
-            raise ValueError('bad subimage height value {!r}'.format(subim_height))
+            raise ValueError("bad subimage height value {!r}".format(subim_height))
         if subim_ix < 0 or subim_ix + subim_width > self._width:
-            raise ValueError('bad subimage ix value {!r}'.format(subim_ix))
+            raise ValueError("bad subimage ix value {!r}".format(subim_ix))
         if subim_iy < 0 or subim_iy + subim_height > self._height:
-            raise ValueError('bad subimage iy value {!r}'.format(subim_iy))
+            raise ValueError("bad subimage iy value {!r}".format(subim_iy))
 
         sub_tiling = StudyTiling(self._width, self._height)
         sub_tiling._width = subim_width
@@ -128,11 +129,9 @@ class StudyTiling(object):
         sub_tiling._img_gy0 += subim_iy
         return sub_tiling
 
-
     def n_deepest_layer_tiles(self):
         """Return the number of tiles in the highest-resolution layer."""
         return 4**self._tile_levels
-
 
     def apply_to_imageset(self, imgset):
         """Fill the specific ``wwt_data_formats.imageset.ImageSet`` object
@@ -154,10 +153,9 @@ class StudyTiling(object):
         imgset.tile_levels = self._tile_levels
 
         if self._tile_levels == 0:
-          imgset.projection = ProjectionType.SKY_IMAGE
+            imgset.projection = ProjectionType.SKY_IMAGE
         else:
-          imgset.projection = ProjectionType.TAN
-
+            imgset.projection = ProjectionType.TAN
 
     def image_to_tile(self, im_ix, im_iy):
         """Convert an image pixel position to a tiled pixel position.
@@ -196,7 +194,6 @@ class StudyTiling(object):
         tile_iy = np.floor(gy // 256).astype(int)
         return (tile_ix, tile_iy, gx % 256, gy % 256)
 
-
     def count_populated_positions(self):
         """
         Count how many tiles contain image data.
@@ -211,7 +208,6 @@ class StudyTiling(object):
         tile_end_tx = img_gx1 // 256
         tile_end_ty = img_gy1 // 256
         return (tile_end_ty + 1 - tile_start_ty) * (tile_end_tx + 1 - tile_start_tx)
-
 
     def generate_populated_positions(self):
         """Generate information about tiles containing image data.
@@ -249,12 +245,16 @@ class StudyTiling(object):
         # image itself) with x=0, y=0 being the left-top corner of the tiled
         # region.
 
-        img_gx1 = self._img_gx0 + self._width - 1  # inclusive: there are image data in this column
+        img_gx1 = (
+            self._img_gx0 + self._width - 1
+        )  # inclusive: there are image data in this column
         img_gy1 = self._img_gy0 + self._height - 1  # ditto
 
         tile_start_tx = self._img_gx0 // 256
         tile_start_ty = self._img_gy0 // 256
-        tile_end_tx = img_gx1 // 256  # inclusive; there are image data in this column of tiles
+        tile_end_tx = (
+            img_gx1 // 256
+        )  # inclusive; there are image data in this column of tiles
         tile_end_ty = img_gy1 // 256  # ditto
 
         for ity in range(tile_start_ty, tile_end_ty + 1):
@@ -295,7 +295,6 @@ class StudyTiling(object):
                     tile_overlap_y0,
                 )
 
-
     def tile_image(self, image, pio, cli_progress=False):
         """Tile an in-memory image as a study.
 
@@ -315,9 +314,9 @@ class StudyTiling(object):
 
         """
         if image.height != self._height:
-            raise ValueError('height of image to be sampled does not match tiling')
+            raise ValueError("height of image to be sampled does not match tiling")
         if image.width != self._width:
-            raise ValueError('width of image to be sampled does not match tiling')
+            raise ValueError("width of image to be sampled does not match tiling")
 
         # For tiled FITS, the overall input image and tiling coordinate system
         # need to have negative (JPEG-like) parity, but the individal tiles need

--- a/toasty/toast.py
+++ b/toasty/toast.py
@@ -387,9 +387,9 @@ def toast_pixel_for_point(depth, lat, lon, coordsys=ToastCoordinateSystem.ASTRON
             flat_lons * 0 + 1,
             flat_lons,
             flat_lats,
-            flat_lons ** 2,
+            flat_lons**2,
             flat_lons * flat_lats,
-            flat_lats ** 2,
+            flat_lats**2,
         ]
     ).T
 
@@ -404,9 +404,9 @@ def toast_pixel_for_point(depth, lat, lon, coordsys=ToastCoordinateSystem.ASTRON
             1,
             lon,
             lat,
-            lon ** 2,
+            lon**2,
             lon * lat,
-            lat ** 2,
+            lat**2,
         ]
     )
     x = np.dot(x_coeff, pt)

--- a/toasty/toast.py
+++ b/toasty/toast.py
@@ -1,5 +1,5 @@
 # -*- mode: python; coding: utf-8 -*-
-# Copyright 2013-2021 Chris Beaumont and the AAS WorldWide Telescope project
+# Copyright 2013-2022 Chris Beaumont and the AAS WorldWide Telescope project
 # Licensed under the MIT License.
 
 """Computations for the TOAST projection scheme and tile pyramid format.
@@ -21,7 +21,6 @@ the square as for sky maps. In other words, the longitudinal orientation is
 rotated by 180 degrees.
 
 """
-from __future__ import absolute_import, division, print_function
 
 __all__ = """
 count_tiles_matching_filter
@@ -41,10 +40,10 @@ toast_tile_get_coords
 from collections import namedtuple
 from enum import Enum
 import numpy as np
-from tqdm import tqdm
 
 from ._libtoasty import subsample, mid
 from .image import Image
+from .progress import progress_bar
 from .pyramid import Pos, tiles_at_depth
 
 HALFPI = 0.5 * np.pi
@@ -646,7 +645,7 @@ def sample_layer(
         parallel processing is not possible and serial processing will be
         forced. Pass ``1`` to force serial processing.
     cli_progress : optional boolean, defaults False
-        If true, a progress bar will be printed to the terminal using tqdm.
+        If true, a progress bar will be printed to the terminal.
     """
 
     from .par_util import resolve_parallelism
@@ -665,7 +664,7 @@ def _sample_layer_serial(pio, format, sampler, depth, coordsys, cli_progress):
     # The usual vertical flip that we may need if tiling into FITS:
     invert_into_tiles = pio.get_default_vertical_parity_sign() == 1
 
-    with tqdm(total=tiles_at_depth(depth), disable=not cli_progress) as progress:
+    with progress_bar(total=tiles_at_depth(depth), show=cli_progress) as progress:
         for tile in generate_tiles(depth, bottom_only=True, coordsys=coordsys):
             lon, lat = toast_tile_get_coords(tile)
             sampled_data = sampler(lon, lat)
@@ -675,9 +674,6 @@ def _sample_layer_serial(pio, format, sampler, depth, coordsys, cli_progress):
 
             pio.write_image(tile.pos, Image.from_array(sampled_data), format=format)
             progress.update(1)
-
-    if cli_progress:
-        print()
 
 
 def _sample_layer_parallel(
@@ -699,7 +695,7 @@ def _sample_layer_parallel(
 
     # Send out tiles:
 
-    with tqdm(total=tiles_at_depth(depth), disable=not cli_progress) as progress:
+    with progress_bar(total=tiles_at_depth(depth), show=cli_progress) as progress:
         for tile in generate_tiles(depth, bottom_only=True, coordsys=coordsys):
             queue.put(tile)
             progress.update(1)
@@ -712,9 +708,6 @@ def _sample_layer_parallel(
 
     for w in workers:
         w.join()
-
-    if cli_progress:
-        print()
 
 
 def _mp_sample_worker(queue, done_event, pio, sampler, format):
@@ -778,7 +771,7 @@ def sample_layer_filtered(
         parallel processing is not possible and serial processing will be
         forced. Pass ``1`` to force serial processing.
     cli_progress : optional boolean, defaults False
-        If true, a progress bar will be printed to the terminal using tqdm.
+        If true, a progress bar will be printed to the terminal.
     """
 
     from .par_util import resolve_parallelism
@@ -803,7 +796,7 @@ def _sample_filtered_serial(pio, tile_filter, sampler, depth, coordsys, cli_prog
     # The usual vertical flip that we may need if tiling into FITS:
     invert_into_tiles = pio.get_default_vertical_parity_sign() == 1
 
-    with tqdm(total=n_todo, disable=not cli_progress) as progress:
+    with progress_bar(total=n_todo, show=cli_progress) as progress:
         for tile in generate_tiles_filtered(
             depth, tile_filter, bottom_only=True, coordsys=coordsys
         ):
@@ -823,9 +816,6 @@ def _sample_filtered_serial(pio, tile_filter, sampler, depth, coordsys, cli_prog
                 )
 
             progress.update(1)
-
-    if cli_progress:
-        print()
 
     # do not clean lockfiles, for HPC contexts where we're processing different
     # chunks in parallel.
@@ -854,7 +844,7 @@ def _sample_filtered_parallel(
 
     # Here we go:
 
-    with tqdm(total=n_todo, disable=not cli_progress) as progress:
+    with progress_bar(total=n_todo, show=cli_progress) as progress:
         for tile in generate_tiles_filtered(
             depth, tile_filter, bottom_only=True, coordsys=coordsys
         ):
@@ -869,9 +859,6 @@ def _sample_filtered_parallel(
 
     for w in workers:
         w.join()
-
-    if cli_progress:
-        print()
 
     # do not clean lockfiles, for HPC contexts where we're processing different
     # chunks in parallel.

--- a/toasty/transform.py
+++ b/toasty/transform.py
@@ -1,5 +1,5 @@
 # -*- mode: python; coding: utf-8 -*-
-# Copyright 2020-2021 the AAS WorldWide Telescope project
+# Copyright 2020-2022 the AAS WorldWide Telescope project
 # Licensed under the MIT License.
 
 """
@@ -14,9 +14,9 @@ u8_to_rgb
 
 from astropy import visualization as viz
 import numpy as np
-from tqdm import tqdm
 
 from .image import ImageMode, Image
+from .progress import progress_bar
 from .pyramid import depth2tiles, generate_pos
 
 
@@ -34,13 +34,11 @@ def _do_a_transform(pio, depth, make_buf, do_one, pio_out=None, parallel=None, c
     else:
         buf = make_buf()
 
-        with tqdm(total=depth2tiles(depth), disable=not cli_progress) as progress:
+        with progress_bar(total=depth2tiles(depth), show=cli_progress) as progress:
             for pos in generate_pos(depth):
                 do_one(buf, pos, pio, pio_out)
                 progress.update(1)
 
-        if cli_progress:
-            print()
 
 
 def _transform_parallel(pio_in, pio_out, depth, make_buf, do_one, cli_progress, parallel):
@@ -60,7 +58,7 @@ def _transform_parallel(pio_in, pio_out, depth, make_buf, do_one, cli_progress, 
 
     # Send out them tiles
 
-    with tqdm(total=depth2tiles(depth), disable=not cli_progress) as progress:
+    with progress_bar(total=depth2tiles(depth), show=cli_progress) as progress:
         for pos in generate_pos(depth):
               queue.put(pos)
               progress.update(1)
@@ -73,9 +71,6 @@ def _transform_parallel(pio_in, pio_out, depth, make_buf, do_one, cli_progress, 
 
     for w in workers:
         w.join()
-
-    if cli_progress:
-        print()
 
 
 def _transform_mp_worker(queue, done_event, pio_in, pio_out, make_buf, do_one):

--- a/toasty/transform.py
+++ b/toasty/transform.py
@@ -2,15 +2,15 @@
 # Copyright 2020-2022 the AAS WorldWide Telescope project
 # Licensed under the MIT License.
 
-"""
-Within-tile data transformations. Mainly, transforming floating-point data to
-RGB.
+"""Within-tile data transformations
+
+Mainly, transforming floating-point data to RGB.
 """
 
-__all__ = '''
+__all__ = """
 f16x3_to_rgb
 u8_to_rgb
-'''.split()
+""".split()
 
 from astropy import visualization as viz
 import numpy as np
@@ -22,15 +22,21 @@ from .pyramid import depth2tiles, generate_pos
 
 # Generalized transform machinery, with both serial and parallel support
 
-def _do_a_transform(pio, depth, make_buf, do_one, pio_out=None, parallel=None, cli_progress=False):
+
+def _do_a_transform(
+    pio, depth, make_buf, do_one, pio_out=None, parallel=None, cli_progress=False
+):
     from .par_util import resolve_parallelism
+
     parallel = resolve_parallelism(parallel)
 
     if pio_out is None:
         pio_out = pio
 
     if parallel > 1:
-        _transform_parallel(pio, pio_out, depth, make_buf, do_one, cli_progress, parallel)
+        _transform_parallel(
+            pio, pio_out, depth, make_buf, do_one, cli_progress, parallel
+        )
     else:
         buf = make_buf()
 
@@ -40,18 +46,22 @@ def _do_a_transform(pio, depth, make_buf, do_one, pio_out=None, parallel=None, c
                 progress.update(1)
 
 
-
-def _transform_parallel(pio_in, pio_out, depth, make_buf, do_one, cli_progress, parallel):
+def _transform_parallel(
+    pio_in, pio_out, depth, make_buf, do_one, cli_progress, parallel
+):
     import multiprocessing as mp
 
     # Start up the workers
 
     done_event = mp.Event()
-    queue = mp.Queue(maxsize = 16 * parallel)
+    queue = mp.Queue(maxsize=16 * parallel)
     workers = []
 
     for _ in range(parallel):
-        w = mp.Process(target=_transform_mp_worker, args=(queue, done_event, pio_in, pio_out, make_buf, do_one))
+        w = mp.Process(
+            target=_transform_mp_worker,
+            args=(queue, done_event, pio_in, pio_out, make_buf, do_one),
+        )
         w.daemon = True
         w.start()
         workers.append(w)
@@ -60,8 +70,8 @@ def _transform_parallel(pio_in, pio_out, depth, make_buf, do_one, cli_progress, 
 
     with progress_bar(total=depth2tiles(depth), show=cli_progress) as progress:
         for pos in generate_pos(depth):
-              queue.put(pos)
-              progress.update(1)
+            queue.put(pos)
+            progress.update(1)
 
     # All done
 
@@ -94,19 +104,22 @@ def _transform_mp_worker(queue, done_event, pio_in, pio_out, make_buf, do_one):
 
 # float-to-RGB(A), with a generalized float-to-unit transform
 
+
 def f16x3_to_rgb(pio, start_depth, clip=1, **kwargs):
     transform = viz.SqrtStretch() + viz.ManualInterval(0, clip)
     _float_to_rgb(pio, start_depth, transform, **kwargs)
 
 
-def _float_to_rgb(pio_in, depth, transform, out_format='png', **kwargs):
+def _float_to_rgb(pio_in, depth, transform, out_format="png", **kwargs):
     make_buf = lambda: np.empty((256, 256, 3), dtype=np.uint8)
-    do_one = lambda buf, pos, pio_in, pio_out: _float_to_rgb_do_one(buf, pos, pio_in, pio_out, transform, out_format)
+    do_one = lambda buf, pos, pio_in, pio_out: _float_to_rgb_do_one(
+        buf, pos, pio_in, pio_out, transform, out_format
+    )
     _do_a_transform(pio_in, depth, make_buf, do_one, **kwargs)
 
 
 def _float_to_rgb_do_one(buf, pos, pio_in, pio_out, transform, out_format):
-    img = pio_in.read_image(pos, format='npy')
+    img = pio_in.read_image(pos, format="npy")
     if img is None:
         return
 
@@ -128,12 +141,14 @@ def _float_to_rgb_do_one(buf, pos, pio_in, pio_out, transform, out_format):
 
 def _float_to_rgba(pio_in, depth, transform, **kwargs):
     make_buf = lambda: np.empty((256, 256, 4), dtype=np.uint8)
-    do_one = lambda buf, pos, pio_in, pio_out: _float_to_rgba_do_one(buf, pos, pio_in, pio_out, transform)
+    do_one = lambda buf, pos, pio_in, pio_out: _float_to_rgba_do_one(
+        buf, pos, pio_in, pio_out, transform
+    )
     _do_a_transform(pio_in, depth, make_buf, do_one, **kwargs)
 
 
 def _float_to_rgba_do_one(buf, pos, pio_in, pio_out, transform):
-    img = pio_in.read_image(pos, format='npy')
+    img = pio_in.read_image(pos, format="npy")
     if img is None:
         return
 
@@ -144,20 +159,21 @@ def _float_to_rgba_do_one(buf, pos, pio_in, pio_out, transform):
         valid = np.isfinite(mapped)
         mapped[~valid] = 0
         mapped = np.clip(mapped * 255, 0, 255).astype(np.uint8)
-        buf[...,:3] = mapped.reshape((256, 256, 1))
-        buf[...,3] = 255 * valid
+        buf[..., :3] = mapped.reshape((256, 256, 1))
+        buf[..., 3] = 255 * valid
     else:
         valid = np.all(np.isfinite(mapped), axis=2)
         mapped[~valid] = 0
         mapped = np.clip(mapped * 255, 0, 255).astype(np.uint8)
-        buf[...,:3] = mapped
-        buf[...,3] = 255 * valid
+        buf[..., :3] = mapped
+        buf[..., 3] = 255 * valid
 
     rgba = Image.from_array(buf)
-    pio_out.write_image(pos, rgba, format='png', mode=ImageMode.RGBA)
+    pio_out.write_image(pos, rgba, format="png", mode=ImageMode.RGBA)
 
 
 # u8-to-RGB
+
 
 def u8_to_rgb(pio, depth, **kwargs):
     make_buf = lambda: np.empty((256, 256, 3), dtype=np.uint8)
@@ -165,10 +181,10 @@ def u8_to_rgb(pio, depth, **kwargs):
 
 
 def _u8_to_rgb_do_one(buf, pos, pio_in, pio_out):
-    img = pio_in.read_image(pos, format='npy')
+    img = pio_in.read_image(pos, format="npy")
     if img is None:
         return
 
-    buf[...] = img.asarray()[...,np.newaxis]
+    buf[...] = img.asarray()[..., np.newaxis]
     rgb = Image.from_array(buf)
-    pio_out.write_image(pos, rgb, format='jpg', mode=ImageMode.RGB)
+    pio_out.write_image(pos, rgb, format="jpg", mode=ImageMode.RGB)


### PR DESCRIPTION
- Finally add the logic to not write out image files if they're completely flagged
- Wrap tqdm progress bars to be tidier when the output is not a TTY (i.e., it is a log file)