### PR TITLE
Add a new `Pyramid` class for dealing with pyramids more robustly

### DIFF
--- a/docs/api/toasty.merge.TileMerger.rst
+++ b/docs/api/toasty.merge.TileMerger.rst
@@ -1,0 +1,17 @@
+TileMerger
+==========
+
+.. currentmodule:: toasty.merge
+
+.. autoclass:: TileMerger
+   :show-inheritance:
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~TileMerger.walk_callback
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: walk_callback

--- a/docs/api/toasty.pyramid.Pyramid.rst
+++ b/docs/api/toasty.pyramid.Pyramid.rst
@@ -1,0 +1,39 @@
+Pyramid
+=======
+
+.. currentmodule:: toasty.pyramid
+
+.. autoclass:: Pyramid
+   :show-inheritance:
+
+   .. rubric:: Attributes Summary
+
+   .. autosummary::
+
+      ~Pyramid.depth
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~Pyramid.count_live_tiles
+      ~Pyramid.count_operations
+      ~Pyramid.new_generic
+      ~Pyramid.new_toast
+      ~Pyramid.new_toast_filtered
+      ~Pyramid.subpyramid
+      ~Pyramid.walk
+
+   .. rubric:: Attributes Documentation
+
+   .. autoattribute:: depth
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: count_live_tiles
+   .. automethod:: count_operations
+   .. automethod:: new_generic
+   .. automethod:: new_toast
+   .. automethod:: new_toast_filtered
+   .. automethod:: subpyramid
+   .. automethod:: walk

--- a/docs/api/toasty.pyramid.get_parents.rst
+++ b/docs/api/toasty.pyramid.get_parents.rst
@@ -1,6 +1,0 @@
-get_parents
-===========
-
-.. currentmodule:: toasty.pyramid
-
-.. autofunction:: get_parents

--- a/toasty/merge.py
+++ b/toasty/merge.py
@@ -173,36 +173,28 @@ class TileMerger(object):
                 )
 
         merged = Image.from_array(self._merger(self._buf.asarray()))
-        min_value, max_value = _get_min_max_of_children(
-            self._pio, [img0, img1, img2, img3]
-        )
+        min_value, max_value = self._get_min_max_of_children([img0, img1, img2, img3])
         self._pio.write_image(pos, merged, min_value=min_value, max_value=max_value)
 
+    def _get_min_max_of_children(self, children):
+        min_value = None
+        max_value = None
 
-def _get_min_max_of_children(pio, children):
-    min_value = None
-    max_value = None
-    if "fits" in pio.get_default_format():
-        min_values = _get_existing_min_values(children)
-        if min_values:  # Check there are any valid min values
-            min_value = min(min_values)
-        max_values = _get_existing_max_values(children)
-        if max_values:  # Check there are any valid max values
-            max_value = max(max_values)
-    return min_value, max_value
+        if "fits" in self._pio.get_default_format():
+            min_values = []
+            max_values = []
 
+            for image in children:
+                if image is not None:
+                    if image.data_min is not None:
+                        min_values.append(image.data_min)
+                    if image.data_max is not None:
+                        max_values.append(image.data_max)
 
-def _get_existing_min_values(images):
-    values = []
-    for image in images:
-        if image is not None and image.data_min is not None:
-            values.append(image.data_min)
-    return values
+            if min_values:  # There may not be any valid values!
+                min_value = min(min_values)
 
+            if max_values:
+                max_value = max(max_values)
 
-def _get_existing_max_values(images):
-    values = []
-    for image in images:
-        if image is not None and image.data_max is not None:
-            values.append(image.data_max)
-    return values
+        return min_value, max_value

--- a/toasty/merge.py
+++ b/toasty/merge.py
@@ -22,6 +22,7 @@ the operation over sets of four adjacent pixels."""
 __all__ = """
 averaging_merger
 cascade_images
+TileMerger
 """.split()
 
 import numpy as np
@@ -71,7 +72,12 @@ def averaging_merger(data):
 
 
 def cascade_images(
-    pio, start, merger, parallel=None, cli_progress=False, tile_filter=None
+    pio,
+    start,
+    merger,
+    parallel=None,
+    cli_progress=False,
+    tile_filter=None,
 ):
     """Downsample image tiles all the way to the top of the pyramid.
 
@@ -99,96 +105,78 @@ def cascade_images(
     tile_filter : callable
         A tile filtering function, suitable for passing to
         :func:`toasty.toast.generate_tiles_filtered`.
-
+    subpyramid_pos : :class:`toasty.pyramid.Pos` or None
+        If specified, the cascade will only occur through a subset of the
+        pyramid, finishing at this position.
     """
-    from .par_util import resolve_parallelism
-
-    parallel = resolve_parallelism(parallel)
+    from .pyramid import Pyramid
 
     if start < 1:
         return  # Nothing to do.
 
-    if parallel > 1:
-        _cascade_images_parallel(
-            pio, start, merger, cli_progress, parallel, tile_filter
-        )
-    else:
-        _cascade_images_serial(pio, start, merger, cli_progress, tile_filter)
-
-
-def _cascade_images_serial(pio, start, merger, cli_progress, tile_filter=None):
-    from .toast import count_tiles_matching_filter, generate_tiles_filtered
-
-    buf = None
-
-    # Pyramids always follow a negative-parity (JPEG-like) coordinate system:
-    # tile X=0,Y=0 is at the top left. The file formats for individual tiles may
-    # share the same parity, or they may be negative: pixel x=0,y=0 is at the
-    # bottom-left. In particular, this is the case for FITS files. When this
-    # happens, we can pretty much cascade as normal, but when putting tile
-    # quartets together we need to y-flip at the tile level.
-
-    if pio.get_default_vertical_parity_sign() == 1:
-        slices = SLICES_OPPOSITE_PARITY
-    else:
-        slices = SLICES_MATCHING_PARITY
-
     if tile_filter is None:
-        total = pyramid.depth2tiles(start - 1)
-        with progress_bar(total=total, show=cli_progress) as progress:
-            for pos in pyramid.generate_pos(
-                start - 1
-            ):  # start layer is already there; we're cascading up
-                _process_tile(pos, buf, pio, slices, merger)
-                progress.update(1)
+        # It's much faster if we can avoid calculating TOAST coordinate
+        # information for the tiles.
+        p = Pyramid.new_generic(start)
     else:
-        # +1 because tile 0 is not counted by count_tiles_matching_filter
-        total = (
-            count_tiles_matching_filter(start - 1, tile_filter, bottom_only=False) + 1
+        p = Pyramid.new_toast_filtered(start, tile_filter)
+
+    proc = TileMerger(pio, merger)
+    p.walk(proc.walk_callback, parallel=parallel, cli_progress=cli_progress)
+
+
+class TileMerger(object):
+    def __init__(self, pio, merger):
+        self._pio = pio
+        self._merger = merger
+        self._buf = None
+
+        # Pyramids always follow a negative-parity (JPEG-like) coordinate system:
+        # tile X=0,Y=0 is at the top left. The file formats for individual tiles may
+        # share the same parity, or they may be negative: pixel x=0,y=0 is at the
+        # bottom-left. In particular, this is the case for FITS files. When this
+        # happens, we can pretty much cascade as normal, but when putting tile
+        # quartets together we need to y-flip at the tile level.
+
+        if pio.get_default_vertical_parity_sign() == 1:
+            self._slices = SLICES_OPPOSITE_PARITY
+        else:
+            self._slices = SLICES_MATCHING_PARITY
+
+    def walk_callback(self, pos):
+        # By construction, the children of this tile have all already been
+        # processed.
+        children = pyramid.pos_children(pos)
+
+        img0 = self._pio.read_image(children[0], default="none")
+        img1 = self._pio.read_image(children[1], default="none")
+        img2 = self._pio.read_image(children[2], default="none")
+        img3 = self._pio.read_image(children[3], default="none")
+
+        if img0 is None and img1 is None and img2 is None and img3 is None:
+            return
+
+        if self._buf is not None:
+            self._buf.clear()
+
+        for slidx, subimg in zip(self._slices, (img0, img1, img2, img3)):
+            if subimg is not None:
+                if self._buf is None:
+                    self._buf = subimg.mode.make_maskable_buffer(512, 512)
+                    self._buf.clear()
+
+                subimg.update_into_maskable_buffer(
+                    self._buf,
+                    slice(None),
+                    slice(None),  # subimage indexer: nothing
+                    *slidx,  # buffer indexer: appropriate sub-quadrant
+                )
+
+        merged = Image.from_array(self._merger(self._buf.asarray()))
+        min_value, max_value = _get_min_max_of_children(
+            self._pio, [img0, img1, img2, img3]
         )
-        with progress_bar(total=total, show=cli_progress) as progress:
-            for tile in generate_tiles_filtered(
-                start - 1, tile_filter, bottom_only=False
-            ):
-                _process_tile(tile.pos, buf, pio, slices, merger)
-                progress.update(1)
-            _process_tile(Pos(0, 0, 0), buf, pio, slices, merger)
-            progress.update(1)
-
-
-def _process_tile(pos, buf, pio, slices, merger):
-    # By construction, the children of this tile have all already been
-    # processed.
-    children = pyramid.pos_children(pos)
-
-    img0 = pio.read_image(children[0], default="none")
-    img1 = pio.read_image(children[1], default="none")
-    img2 = pio.read_image(children[2], default="none")
-    img3 = pio.read_image(children[3], default="none")
-
-    if img0 is None and img1 is None and img2 is None and img3 is None:
-        return
-
-    if buf is not None:
-        buf.clear()
-
-    for slidx, subimg in zip(slices, (img0, img1, img2, img3)):
-        if subimg is not None:
-            if buf is None:
-                buf = subimg.mode.make_maskable_buffer(512, 512)
-                buf.clear()
-
-            subimg.update_into_maskable_buffer(
-                buf,
-                slice(None),
-                slice(None),  # subimage indexer: nothing
-                *slidx,  # buffer indexer: appropriate sub-quadrant
-            )
-
-    merged = Image.from_array(merger(buf.asarray()))
-    min_value, max_value = _get_min_max_of_children(pio, [img0, img1, img2, img3])
-
-    pio.write_image(pos, merged, min_value=min_value, max_value=max_value)
+        self._pio.write_image(pos, merged, min_value=min_value, max_value=max_value)
 
 
 def _get_min_max_of_children(pio, children):
@@ -218,161 +206,3 @@ def _get_existing_max_values(images):
         if image is not None and image.data_max is not None:
             values.append(image.data_max)
     return values
-
-
-def _cascade_images_parallel(pio, start, merger, cli_progress, parallel, tile_filter):
-    """Parallelized cascade operation
-
-    At the moment, we require fork-based multiprocessing because the PyramidIO
-    and ``merger`` items are not pickle-able. This could be relaxed, but we
-    might plausibly want to support custom merger functions, so pickle-ability
-    is likely to be a continuing issue.
-
-    """
-    import multiprocessing as mp
-    from queue import Empty
-    from .pyramid import Pos, pos_parent
-    from .toast import count_tiles_matching_filter, generate_tiles_filtered
-
-    # The dispatcher process keeps track of finished tiles (reported in
-    # `done_queue`) and notifiers worker when new tiles are ready to process
-    # (`ready_queue`).
-
-    first_level_to_do = start - 1
-    if tile_filter is None:
-        n_todo = pyramid.depth2tiles(first_level_to_do)
-    else:
-        n_todo = (
-            count_tiles_matching_filter(
-                first_level_to_do, tile_filter, bottom_only=False
-            )
-            + 1
-        )  # +1 because tile 0 is not counted by count_tiles_matching_filter
-    ready_queue = mp.Queue()
-    done_queue = mp.Queue(maxsize=2 * parallel)
-    done_event = mp.Event()
-
-    # Seed the queue of ready tiles. We use generate_pos to try to seed the
-    # queue in an order that will get us to generate higher-level tiles as early
-    # as possible, to make it easier to evaluate the output during processing ...
-    # but in practice this isn't working. Seems that we're saturating the ready
-    # queue before any higher-level tiles can become eligible for processing.
-    readiness = {}
-    if tile_filter is None:
-        for pos in pyramid.generate_pos(first_level_to_do):
-            if pos.n == first_level_to_do:
-                ready_queue.put(pos)
-    else:
-        tiles_to_process = set()
-        for tile in generate_tiles_filtered(
-            first_level_to_do, tile_filter, bottom_only=True
-        ):
-            ready_queue.put(tile.pos)
-            tiles_to_process.add(tile.pos)
-        _initiate_readiness_state(tiles_to_process, readiness)
-
-    # The workers pick up tiles that are ready to process and do the merging.
-
-    workers = []
-
-    for _ in range(parallel):
-        w = mp.Process(
-            target=_mp_cascade_worker,
-            args=(done_queue, ready_queue, done_event, pio, merger),
-        )
-        w.daemon = True
-        w.start()
-        workers.append(w)
-
-    # Start dispatching tiles
-
-    with progress_bar(total=n_todo, show=cli_progress) as progress:
-        while True:
-            # Did anybody finish a tile?
-            try:
-                pos = done_queue.get(True, timeout=1)
-            except (OSError, ValueError, Empty):
-                # OSError or ValueError => queue closed. This signal seems not to
-                # cross multiprocess lines, though.
-                continue
-
-            progress.update(1)
-
-            # If the n=0 tile was done, that's everything.
-            if pos.n == 0:
-                break
-
-            # If this tile was finished, its parent is one step
-            # closer to being ready to process.
-            ppos, x_index, y_index = pos_parent(pos)
-            bit_num = 2 * y_index + x_index
-            flags = readiness.get(ppos, 0)
-            flags |= 1 << bit_num
-
-            # If this tile was the last of its siblings to be finished,
-            # the parent is now ready for processing.
-            if flags == 0xF:
-                readiness.pop(ppos)
-                ready_queue.put(ppos)
-            else:
-                readiness[ppos] = flags
-
-    # All done!
-
-    ready_queue.close()
-    ready_queue.join_thread()
-    done_event.set()
-
-    for w in workers:
-        w.join()
-
-
-def _mp_cascade_worker(done_queue, ready_queue, done_event, pio, merger):
-    """
-    Process tiles that are ready.
-    """
-    from queue import Empty
-
-    buf = None
-
-    # See discussion in the serial implementation.
-    if pio.get_default_vertical_parity_sign() == 1:
-        slices = SLICES_OPPOSITE_PARITY
-    else:
-        slices = SLICES_MATCHING_PARITY
-
-    while True:
-        try:
-            pos = ready_queue.get(True, timeout=1)
-        except Empty:
-            if done_event.is_set():
-                break
-            continue
-
-        _process_tile(pos, buf, pio, slices, merger)
-
-        done_queue.put(pos)
-
-
-def _initiate_readiness_state(tiles_to_process, readiness):
-    """
-    Marking sibling tiles with no data (as well as their ancestors) as already processed.
-    This allows us to properly detect when ancestors of the tiles to be processed are
-    actually ready to be processed (i.e. when all children of a tile are marked as processed)
-    """
-    from .pyramid import pos_children, get_parents
-
-    if len(tiles_to_process) == 0 or Pos(0, 0, 0) in tiles_to_process:
-        return
-
-    parents = get_parents(tiles_to_process, get_all_ancestors=False)
-    for parent in parents:
-        for child in pos_children(parent):
-            if child not in tiles_to_process:
-                flags = readiness.get(parent, 0)
-                # Using the child's position within the parent tile (0-1x, 0-1y)
-                bit_num = 2 * (child.y % 2) + child.x % 2
-                flags |= 1 << bit_num
-                readiness[parent] = flags
-
-    _initiate_readiness_state(parents, readiness)

--- a/toasty/pyramid.py
+++ b/toasty/pyramid.py
@@ -18,7 +18,6 @@ next_highest_power_of_2
 Pos
 pos_children
 pos_parent
-get_parents
 guess_base_layer_level
 Pyramid
 PyramidIO
@@ -170,42 +169,6 @@ def generate_pos(depth):
     """
     for item in _postfix_pos(Pos(0, 0, 0), depth):
         yield item
-
-
-def get_parents(pos_collection, get_all_ancestors=False):
-    """Return a set of all parents or ancestors of a collection of tiles.
-
-    Parameters
-    ----------
-    pos_collection : list or set of :class:`Pos`
-        The collection of :class:`Pos` to find all parents for.
-        This collection cannot contain Pos of differing levels (n values).
-    get_all_ancestors : boolean, defaults to False
-        Choose this if you want to get all ancestors, and not just the parent tiles.
-
-    Yields
-    ------
-    parents : set of :class:`Pos`
-        A set containing the :class:`Pos` of all parents for the input.
-
-    """
-    parents = set()
-    if any(
-        x in pos_collection
-        for x in (Pos(1, 0, 0), Pos(1, 0, 1), Pos(1, 1, 0), Pos(1, 1, 1))
-    ):
-        parents.add(Pos(0, 0, 0))
-        return parents
-
-    for pos in pos_collection:
-        parent_pos = pos_parent(pos)[0]
-        parents.add(parent_pos)
-
-    if get_all_ancestors:
-        grandparents = get_parents(parents, get_all_ancestors)
-        parents = parents.union(grandparents)
-
-    return parents
 
 
 def guess_base_layer_level(wcs):

--- a/toasty/pyramid.py
+++ b/toasty/pyramid.py
@@ -1151,13 +1151,12 @@ class PyramidReductionIterator(object):
         if self._most_recent_pos == self._pyramid._apex:
             # If we hit the apex (which is (0, 0, 0) when no subpyramiding is
             # active, the next `next()` call should trigger a StopIteration.
-            self._generator = iter([])
+            self._generator = None
             self._final_result = value
         else:
             # Otherwise, log this result in the appropriate entry for this
             # tile's parent.
             ppos, ix, iy = pos_parent(self._most_recent_pos)
-            self._ensure_levels(ppos)
             assert self._levels[ppos.n][0] == ppos.x
             assert self._levels[ppos.n][1] == ppos.y
             self._levels[ppos.n][2 + 2 * iy + ix] = value

--- a/toasty/pyramid.py
+++ b/toasty/pyramid.py
@@ -743,6 +743,10 @@ class Pyramid(object):
         if self.depth > 9 and self._tile_filter is not None:
             print(f"... {time.time() - t0:.1f}s elapsed")
 
+        if total == 0:
+            print("- Nothing to do.")
+            return
+
         # In serial mode, we can do actual processing as another reduction:
 
         riter = self._make_iter_reducer(default_value=False)
@@ -829,6 +833,10 @@ class Pyramid(object):
             print(
                 f"... {time.time() - t0:.1f}s elapsed; queue size {ready_queue.qsize()}; ready map size {len(readiness)}"
             )
+
+        if total == 0:
+            print("- Nothing to do.")
+            return
 
         # Ready to create workers! These workers pick up tiles that are ready to
         # process and do the merging.

--- a/toasty/pyramid.py
+++ b/toasty/pyramid.py
@@ -726,6 +726,37 @@ class Pyramid(object):
 
         return PyramidReductionIterator(self, default_value=default_value)
 
+    def count_leaf_tiles(self):
+        """Count the number of leaf tiles in the current pyramid.
+
+        Returns
+        -------
+        The number of leaf tiles.
+
+        Notes
+        -----
+        A leaf tile is a tile whose level is equal to the depth of the pyramid.
+
+        This calculation is non-trivial if tile filtering is in effect, and in
+        fact requires iterating over essentially the entire pyramid to ensure
+        that all of the tiles at the deepest layer are visited."""
+
+        if self._tile_filter is None:
+            # In this case, we know analytically.
+            return tiles_at_depth(self.depth - self._apex.n)
+
+        riter = self._make_iter_reducer(default_value=0)
+
+        for _pos, _tile, is_leaf, data in riter:
+            if is_leaf:
+                count = 1
+            else:
+                count = data[0] + data[1] + data[2] + data[3]
+
+            riter.set_data(count)
+
+        return riter.result()
+
     def count_live_tiles(self):
         """Count the number of "live" tiles in the current pyramid.
 
@@ -773,7 +804,8 @@ class Pyramid(object):
         -----
         See :meth:`count_live_tiles` for a definition of liveness. The return
         value of this function is equal to the number of live tiles that are not
-        also leaf tiles."""
+        also leaf tiles. Therefore, ``count_operations() + count_leaf_tiles() =
+        count_live_tiles()``."""
 
         if self._tile_filter is None:
             # In this case, we know analytically.

--- a/toasty/samplers.py
+++ b/toasty/samplers.py
@@ -709,6 +709,12 @@ def _latlon_tile_filter(image_lon_min, image_lon_max, image_lat_min, image_lat_m
 
     Usual bounding box semantics apply. If your bounding box is "too big" the
     only problem is that more tiles are touched than strictly necessary.
+
+    Note that this filter can give somewhat surprising semantics: if the filter
+    matches tile T, it is possible that it does not match any of T's children.
+    This is because we're doing a bounding-box test, and it is possible that the
+    bounding box of T overlaps the image while the union of the bounding boxes
+    of T's children does not.
     """
     assert image_lon_min < image_lon_max
     assert image_lat_min < image_lat_max

--- a/toasty/samplers.py
+++ b/toasty/samplers.py
@@ -566,7 +566,7 @@ class WcsSampler(object):
         coarse_edge_lons[2 * nm : 3 * nm] = coarse_lon[-1:0:-1, nm]
         coarse_edge_lons[3 * nm :] = coarse_lon[0, -1::-1]
 
-        deltas = np.zeros(coarse_edge_lons.shape, dtype=np.int)
+        deltas = np.zeros(coarse_edge_lons.shape, dtype=int)
 
         for i in range(1, coarse_edge_lons.size):
             v0 = coarse_edge_lons[i - 1]

--- a/toasty/tests/test_merge.py
+++ b/toasty/tests/test_merge.py
@@ -1,11 +1,10 @@
 # -*- mode: python; coding: utf-8 -*-
-# Copyright 2019-2020 the AAS WorldWide Telescope project
+# Copyright 2019-2022 the AAS WorldWide Telescope project
 # Licensed under the MIT License.
 
 import numpy as np
 import numpy.testing as nt
 import os.path
-import pytest
 
 from . import test_path
 from .. import cli
@@ -13,27 +12,8 @@ from .. import merge
 
 
 def test_averaging_merger():
-    from ..merge import averaging_merger
-
     t = np.array([[np.nan, 1], [3, np.nan]])
-    nt.assert_almost_equal(averaging_merger(t), [[2.0]])
-
-
-def test_initiate_readiness_state():
-    from ..merge import _initiate_readiness_state
-    from ..pyramid import Pos
-
-    readiness_state = {}
-    _initiate_readiness_state({Pos(1, 0, 0), Pos(1, 1, 0)}, readiness_state)
-    assert readiness_state.get(Pos(n=0, x=0, y=0)) == 0b1100
-
-    readiness_state = {}
-    _initiate_readiness_state({Pos(3, 7, 7), Pos(3, 3, 1)}, readiness_state)
-    assert readiness_state.get(Pos(n=0, x=0, y=0)) == 0b0110
-    assert readiness_state.get(Pos(n=1, x=1, y=1)) == 0b0111
-    assert readiness_state.get(Pos(n=1, x=0, y=0)) == 0b1101
-    assert readiness_state.get(Pos(n=2, x=3, y=3)) == 0b0111
-    assert readiness_state.get(Pos(n=2, x=1, y=0)) == 0b0111
+    nt.assert_almost_equal(merge.averaging_merger(t), [[2.0]])
 
 
 class TestCascade(object):

--- a/toasty/tests/test_pyramid.py
+++ b/toasty/tests/test_pyramid.py
@@ -39,34 +39,6 @@ def test_pos_parent():
         pos_parent(Pos(0, 0, 0))
 
 
-def test_get_parents():
-    from ..pyramid import get_parents
-
-    assert get_parents((Pos(1, 0, 0), Pos(1, 1, 0))) == {Pos(0, 0, 0)}
-
-    all_ancestors = {
-        Pos(n=0, x=0, y=0),
-        Pos(n=1, x=0, y=0),
-        Pos(n=1, x=1, y=0),
-        Pos(n=2, x=1, y=1),
-        Pos(n=2, x=2, y=1),
-        Pos(n=3, x=3, y=2),
-        Pos(n=3, x=4, y=2),
-        Pos(n=4, x=7, y=4),
-        Pos(n=4, x=8, y=4),
-        Pos(n=5, x=15, y=8),
-        Pos(n=5, x=16, y=8),
-        Pos(n=6, x=31, y=16),
-        Pos(n=6, x=32, y=16),
-    }
-    assert (
-        get_parents(
-            {Pos(7, 63, 33), Pos(7, 64, 33), Pos(7, 65, 33)}, get_all_ancestors=True
-        )
-        == all_ancestors
-    )
-
-
 def test_generate_pos():
     from ..pyramid import generate_pos
 

--- a/toasty/tests/test_pyramid.py
+++ b/toasty/tests/test_pyramid.py
@@ -1,8 +1,7 @@
 # -*- mode: python; coding: utf-8 -*-
-# Copyright 2019 the AAS WorldWide Telescope project
+# Copyright 2019-2022 the AAS WorldWide Telescope project
 # Licensed under the MIT License.
 
-import numpy as np
 import pytest
 
 from .. import pyramid
@@ -106,3 +105,133 @@ def test_guess_base_layer_level():
 
     wcs.wcs.cdelt = 0.0001, 0.0001
     assert guess_base_layer_level(wcs=wcs) == 13
+
+
+def test_pyramid_gen_generic():
+    p = pyramid.Pyramid.new_generic(0)
+
+    assert list(p._generator()) == [(Pos(0, 0, 0), None)]
+    assert p.count_live_tiles() == 1
+    assert p.count_operations() == 0
+
+    p = pyramid.Pyramid.new_generic(1)
+
+    assert list(p._generator()) == [
+        (Pos(1, 0, 0), None),
+        (Pos(1, 1, 0), None),
+        (Pos(1, 0, 1), None),
+        (Pos(1, 1, 1), None),
+        (Pos(0, 0, 0), None),
+    ]
+    assert p.count_live_tiles() == 5
+    assert p.count_operations() == 1
+
+    p = pyramid.Pyramid.new_generic(2).subpyramid(Pos(1, 1, 1))
+
+    assert list(p._generator()) == [
+        (Pos(2, 2, 2), None),
+        (Pos(2, 3, 2), None),
+        (Pos(2, 2, 3), None),
+        (Pos(2, 3, 3), None),
+        (Pos(1, 1, 1), None),
+        (Pos(0, 0, 0), None),
+    ]
+    assert p.count_live_tiles() == 5
+    assert p.count_operations() == 1
+
+
+def test_pyramid_gen_toast():
+    p = pyramid.Pyramid.new_toast(0)
+
+    assert list([t[0] for t in p._generator()]) == [Pos(0, 0, 0)]
+    assert p.count_live_tiles() == 1
+    assert p.count_operations() == 0
+
+    p = pyramid.Pyramid.new_toast(1)
+
+    assert list([t[0] for t in p._generator()]) == [
+        Pos(1, 0, 0),
+        Pos(1, 1, 0),
+        Pos(1, 0, 1),
+        Pos(1, 1, 1),
+        Pos(0, 0, 0),
+    ]
+    assert p.count_live_tiles() == 5
+    assert p.count_operations() == 1
+
+    p = pyramid.Pyramid.new_toast(2).subpyramid(Pos(1, 1, 1))
+
+    assert list([t[0] for t in p._generator()]) == [
+        Pos(2, 2, 2),
+        Pos(2, 3, 2),
+        Pos(2, 2, 3),
+        Pos(2, 3, 3),
+        Pos(1, 1, 1),
+        Pos(0, 0, 0),
+    ]
+    assert p.count_live_tiles() == 5
+    assert p.count_operations() == 1
+
+
+def test_pyramid_gen_toast_filtered():
+    from ..samplers import _latlon_tile_filter
+
+    # These bounds are roughly from the DECaPS2 dataset
+    # which I've been processing.
+    tf = _latlon_tile_filter(0.106, 4.878, -1.285, -0.120)
+
+    p = pyramid.Pyramid.new_toast_filtered(0, tf)
+
+    assert list([t[0] for t in p._generator()]) == [Pos(0, 0, 0)]
+    assert p.count_live_tiles() == 1
+    assert p.count_operations() == 0
+
+    p = pyramid.Pyramid.new_toast_filtered(3, tf)
+    REFXY = [
+        (0, 0),
+        (0, 1),
+        (0, 2),
+        (0, 3),
+        (1, 0),
+        (1, 3),
+        (2, 0),
+        (2, 3),
+        (3, 0),
+        (3, 1),
+        (3, 3),
+    ]
+    assert sorted(t[0] for t in p._generator() if t[0].n == 2) == [
+        Pos(2, *t) for t in REFXY
+    ]
+    assert p.count_live_tiles() == 50
+    assert p.count_operations() == 16
+
+
+def test_pyramid_toast_filtered_gap_child():
+    """
+    This examines a corner case where the tile filter matches the level-4 tile
+    in question, but not any of its children -- this is correct behavior because
+    the filtering is only done with bounding boxes, and the union of the
+    bounding boxes of the children is smaller than the bounding box of the
+    parent. Correct behavior for the pyramid is to say that we have no live
+    tiles.
+    """
+    from ..samplers import _latlon_tile_filter
+
+    THE_POS = Pos(4, 15, 7)
+
+    # These bounds are roughly from the DECaPS2 dataset
+    # which I've been processing.
+    tf = _latlon_tile_filter(0.106, 4.878, -1.285, -0.120)
+
+    p = pyramid.Pyramid.new_toast_filtered(4, tf)
+    riter = p._make_iter_reducer()
+
+    for pos, tile, _is_leaf, _data in riter:
+        if pos == THE_POS:
+            assert tf(tile)
+        riter.set_data(True)
+
+    p = pyramid.Pyramid.new_toast_filtered(6, tf).subpyramid(THE_POS)
+    assert p.count_live_tiles() == 0
+    assert p.count_operations() == 0

--- a/toasty/tests/test_pyramid.py
+++ b/toasty/tests/test_pyramid.py
@@ -83,6 +83,7 @@ def test_pyramid_gen_generic():
     p = pyramid.Pyramid.new_generic(0)
 
     assert list(p._generator()) == [(Pos(0, 0, 0), None)]
+    assert p.count_leaf_tiles() == 1
     assert p.count_live_tiles() == 1
     assert p.count_operations() == 0
 
@@ -95,6 +96,7 @@ def test_pyramid_gen_generic():
         (Pos(1, 1, 1), None),
         (Pos(0, 0, 0), None),
     ]
+    assert p.count_leaf_tiles() == 4
     assert p.count_live_tiles() == 5
     assert p.count_operations() == 1
 
@@ -108,6 +110,7 @@ def test_pyramid_gen_generic():
         (Pos(1, 1, 1), None),
         (Pos(0, 0, 0), None),
     ]
+    assert p.count_leaf_tiles() == 4
     assert p.count_live_tiles() == 5
     assert p.count_operations() == 1
 
@@ -116,6 +119,7 @@ def test_pyramid_gen_toast():
     p = pyramid.Pyramid.new_toast(0)
 
     assert list([t[0] for t in p._generator()]) == [Pos(0, 0, 0)]
+    assert p.count_leaf_tiles() == 1
     assert p.count_live_tiles() == 1
     assert p.count_operations() == 0
 
@@ -128,6 +132,7 @@ def test_pyramid_gen_toast():
         Pos(1, 1, 1),
         Pos(0, 0, 0),
     ]
+    assert p.count_leaf_tiles() == 4
     assert p.count_live_tiles() == 5
     assert p.count_operations() == 1
 
@@ -141,6 +146,7 @@ def test_pyramid_gen_toast():
         Pos(1, 1, 1),
         Pos(0, 0, 0),
     ]
+    assert p.count_leaf_tiles() == 4
     assert p.count_live_tiles() == 5
     assert p.count_operations() == 1
 
@@ -155,6 +161,7 @@ def test_pyramid_gen_toast_filtered():
     p = pyramid.Pyramid.new_toast_filtered(0, tf)
 
     assert list([t[0] for t in p._generator()]) == [Pos(0, 0, 0)]
+    assert p.count_leaf_tiles() == 1
     assert p.count_live_tiles() == 1
     assert p.count_operations() == 0
 
@@ -175,6 +182,7 @@ def test_pyramid_gen_toast_filtered():
     assert sorted(t[0] for t in p._generator() if t[0].n == 2) == [
         Pos(2, *t) for t in REFXY
     ]
+    assert p.count_leaf_tiles() == 34
     assert p.count_live_tiles() == 50
     assert p.count_operations() == 16
 
@@ -205,5 +213,6 @@ def test_pyramid_toast_filtered_gap_child():
         riter.set_data(True)
 
     p = pyramid.Pyramid.new_toast_filtered(6, tf).subpyramid(THE_POS)
+    assert p.count_leaf_tiles() == 0
     assert p.count_live_tiles() == 0
     assert p.count_operations() == 0

--- a/toasty/toast.py
+++ b/toasty/toast.py
@@ -566,8 +566,9 @@ def generate_tiles_filtered(
 
     """
     for t in _create_level1_tiles(coordsys):
-        for item in _postfix_corner(t, depth, filter, bottom_only):
-            yield item
+        if filter(t):
+            for item in _postfix_corner(t, depth, filter, bottom_only):
+                yield item
 
 
 def count_tiles_matching_filter(

--- a/toasty/toast.py
+++ b/toasty/toast.py
@@ -431,7 +431,7 @@ def _postfix_corner(tile, depth, filter, bottom_only):
         If True, only yield tiles at max_depth.
 
     """
-    n = tile[0].n
+    n = tile.pos.n
     if n > depth:
         return
 


### PR DESCRIPTION
Here we add a new `toasty.pyramid.Pyramid` class for better managing operations on tile pyramids. I've worked out some formalisms and ways to talk about the pyramid that I think will simplify a lot of things going forward. In this particular PR, we convert the "merge" (image cascade) functionality to use the new approach.

There is new functionality here in that we can now process "subpyramids", where we can do a reduction cascade over only a piece of a larger pyramid. This was necessary for DECaPS2 processing, where the full level=14 TOAST pyramid was going to take too long to process within a single process, even with a lot of CPUs. This is a slight generalization of our existing "tile filter" approach, but the complexity of implementing it within the earlier framework motivated me work out this new system.

One of the key improvements is the "reduction iterator" system for thinking about a depth-first pyramid walk as a reduction operation. The key thing is that it's not easy to parallelize reductions, so we can (should) only use the new iterator for relatively cheap computations. Image cascading must be done with the "walk" framework, which offers the possibility of parallelization but cannot "reduce". The basic problem with parallelizing reductions is transmitting data between processes, which is definitely solvable, but not something I want to deal with right now.

We use the new reduction iterator to speed up the initialization of parallelized, filtered TOAST cascades, because the previous implementation was basically walking the tree several times to compute all of the stuff that it needed to have to manage the parallelized cascade.

A nice extension would be to add a `visit_leaves()` method and port a bunch of our other operations over to use it. Should be pretty easy to do that now that the framework is in place.