### PR TITLE
Add Pyramid.visit_leaves()

### DIFF
--- a/docs/api/toasty.pyramid.Pyramid.rst
+++ b/docs/api/toasty.pyramid.Pyramid.rst
@@ -16,12 +16,14 @@ Pyramid
 
    .. autosummary::
 
+      ~Pyramid.count_leaf_tiles
       ~Pyramid.count_live_tiles
       ~Pyramid.count_operations
       ~Pyramid.new_generic
       ~Pyramid.new_toast
       ~Pyramid.new_toast_filtered
       ~Pyramid.subpyramid
+      ~Pyramid.visit_leaves
       ~Pyramid.walk
 
    .. rubric:: Attributes Documentation
@@ -30,10 +32,12 @@ Pyramid
 
    .. rubric:: Methods Documentation
 
+   .. automethod:: count_leaf_tiles
    .. automethod:: count_live_tiles
    .. automethod:: count_operations
    .. automethod:: new_generic
    .. automethod:: new_toast
    .. automethod:: new_toast_filtered
    .. automethod:: subpyramid
+   .. automethod:: visit_leaves
    .. automethod:: walk

--- a/docs/api/toasty.toast.ToastSampler.rst
+++ b/docs/api/toasty.toast.ToastSampler.rst
@@ -1,0 +1,17 @@
+ToastSampler
+============
+
+.. currentmodule:: toasty.toast
+
+.. autoclass:: ToastSampler
+   :show-inheritance:
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~ToastSampler.visit_callback
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: visit_callback

--- a/toasty/pyramid.py
+++ b/toasty/pyramid.py
@@ -28,6 +28,7 @@ import glob
 from collections import namedtuple
 from contextlib import contextmanager
 import os.path
+import time
 
 from .image import ImageLoader, SUPPORTED_FORMATS, get_format_vertical_parity_sign
 from .progress import progress_bar
@@ -888,8 +889,6 @@ class Pyramid(object):
             self._walk_serial(callback, cli_progress)
 
     def _walk_serial(self, callback, cli_progress):
-        import time
-
         if self.depth > 9 and self._tile_filter is not None:
             # This is around where there are enough tiles that the prep stage
             # might take a noticeable amount of time.
@@ -925,8 +924,6 @@ class Pyramid(object):
     def _walk_parallel(self, callback, cli_progress, parallel):
         import multiprocessing as mp
         from queue import Empty
-        import time
-        from tqdm import tqdm
 
         # When dispatching we keep track of finished tiles (reported in
         # `done_queue`) and notify workers when new tiles are ready to process
@@ -1042,6 +1039,137 @@ class Pyramid(object):
                     ready_queue.put(ppos)
                 else:
                     readiness[ppos] = flags
+
+        # All done!
+
+        ready_queue.close()
+        ready_queue.join_thread()
+        done_event.set()
+
+        for w in workers:
+            w.join()
+
+    def visit_leaves(
+        self,
+        callback,
+        parallel=None,
+        cli_progress=False,
+    ):
+        """Traverse the pyramid, calling the callback for each
+        leaf tile.
+
+        Parameters
+        ----------
+        callback : function(:class:`Pos`, Optional[:class:`~toasty.toast.Tile`])
+        -> None
+            A function to be called for all of the leaves.
+        parallel : integer or None (the default)
+            The level of parallelization to use. If unspecified, defaults to
+            using all CPUs. If the OS does not support fork-based
+            multiprocessing, parallel processing is not possible and serial
+            processing will be forced. Pass ``1`` to force serial processing.
+        cli_progress : optional boolean, defaults False
+            If true, a progress bar will be printed to the terminal.
+
+        Returns
+        -------
+        None.
+
+        Notes
+        -----
+        Use this function to visit all of the leaves of the pyramid, with the
+        possibility of parallelizing the computation substantially using
+        Python's multiprocessing framework.
+
+        Here, "all" of the leaves means ones that have not been filtered out by
+        the use of a TOAST tile filter and/or subpyramid selection.
+
+        The callback is passed the position of the leaf tile and, if the pyramid
+        has been defined as a TOAST tile pyramid, its TOAST coordinate
+        information. If not, the second argument to the callback will be None.
+        In the corner case that this pyramid has depth 0, the TOAST tile
+        information will be None even if this is a TOAST pyramid, because the
+        TOAST tile information is not well-defined at level 0.
+
+        In the parallelized case, callbacks may occur in different processes and
+        so cannot communicate with each other in memory, nor can they
+        communicate with the parent process (that is, the process in which this
+        function was invoked). No guarantees are made about the order in which
+        leaf tiles are visited.
+        """
+
+        from .par_util import resolve_parallelism
+
+        parallel = resolve_parallelism(parallel)
+
+        # Unlike walk(), where the parallel case needs some extra logic to
+        # maintain our ordering guarantees, the serial and parallel cases here
+        # are pretty similar, so we can reuse more code. First, assess the
+        # amount of work to do.
+
+        if self.depth > 9 and self._tile_filter is not None:
+            # This is around where there are enough tiles that the prep stage
+            # might take a noticeable amount of time.
+            print("Counting tiles ...")
+            t0 = time.time()
+
+        total = self.count_leaf_tiles()
+
+        if self.depth > 9 and self._tile_filter is not None:
+            print(f"... {time.time() - t0:.1f}s elapsed")
+
+        if total == 0:
+            print("- Nothing to do.")
+            return
+
+        # Now the meat of it.
+
+        if parallel > 1:
+            self._visit_leaves_parallel(callback, total, cli_progress, parallel)
+        else:
+            self._visit_leaves_serial(callback, total, cli_progress)
+
+    def _visit_leaves_serial(self, callback, total, cli_progress):
+        riter = self._make_iter_reducer()
+
+        with progress_bar(total=total, show=cli_progress) as progress:
+            for pos, tile, is_leaf, _data in riter:
+                if is_leaf:
+                    callback(pos, tile)
+                    progress.update(1)
+
+                riter.set_data(None)
+
+    def _visit_leaves_parallel(self, callback, total, cli_progress, parallel):
+        import multiprocessing as mp
+
+        ready_queue = mp.Queue(maxsize=2 * parallel)
+        done_event = mp.Event()
+
+        # Create workers:
+
+        workers = []
+
+        for _ in range(parallel):
+            w = mp.Process(
+                target=_mp_visit_worker,
+                args=(ready_queue, done_event, callback),
+            )
+            w.daemon = True
+            w.start()
+            workers.append(w)
+
+        # Dispatch:
+
+        riter = self._make_iter_reducer()
+
+        with progress_bar(total=total, show=cli_progress) as progress:
+            for pos, tile, is_leaf, _data in riter:
+                if is_leaf:
+                    ready_queue.put((pos, tile))
+                    progress.update(1)
+
+                riter.set_data(None)
 
         # All done!
 
@@ -1252,3 +1380,20 @@ def _mp_walk_worker(done_queue, ready_queue, done_event, callback):
 
         callback(pos)
         done_queue.put(pos)
+
+
+def _mp_visit_worker(ready_queue, done_event, callback):
+    """
+    Process tiles that are ready.
+    """
+    from queue import Empty
+
+    while True:
+        try:
+            args = ready_queue.get(True, timeout=1)
+        except Empty:
+            if done_event.is_set():
+                break
+            continue
+
+        callback(*args)

--- a/toasty/pyramid.py
+++ b/toasty/pyramid.py
@@ -215,6 +215,13 @@ class PyramidIO(object):
         reading/writing tiles. If not specified, and base_dir exists and
         contains files, these are used to guess default_format. Otherwise
         defaults to 'png'.
+
+    Notes
+    -----
+    If ``default_format`` is unspecified, the default guessing process iterates
+    over the pyramid until it finds a file. In a very large pyramid, this can be
+    quite I/O-intensive, so in large tasks you should specify the default
+    explicitly.
     """
 
     def __init__(self, base_dir, scheme="L/Y/YX", default_format=None):
@@ -261,8 +268,10 @@ class PyramidIO(object):
         Notes
         -----
         In its default mode this function does I/O itself — it creates the
-        parent directories containing the tile path. It is not an error for
-        the parent directories to already exist.
+        parent directories containing the tile path. It is not an error for the
+        parent directories to already exist. When reading data from a large,
+        existing pyramid, I/O performance might be improved significantly by
+        making sure to set ``makedirs = False``.
         """
 
         level = str(pos.n)
@@ -343,7 +352,7 @@ class PyramidIO(object):
         masked_mode : :class:`toasty.image.ImageMode`
             The image data mode to use if ``default`` is set to ``'masked'``.
         """
-        p = self.tile_path(pos, format=format)
+        p = self.tile_path(pos, format=format, makedirs=False)
 
         loader = ImageLoader()
 

--- a/toasty/toast.py
+++ b/toasty/toast.py
@@ -31,6 +31,7 @@ sample_layer
 sample_layer_filtered
 Tile
 ToastCoordinateSystem
+ToastSampler
 toast_pixel_for_point
 toast_tile_area
 toast_tile_for_point
@@ -649,92 +650,11 @@ def sample_layer(
         If true, a progress bar will be printed to the terminal.
     """
 
-    from .par_util import resolve_parallelism
+    from .pyramid import Pyramid
 
-    parallel = resolve_parallelism(parallel)
-
-    if parallel > 1:
-        _sample_layer_parallel(
-            pio, format, sampler, depth, coordsys, cli_progress, parallel
-        )
-    else:
-        _sample_layer_serial(pio, format, sampler, depth, coordsys, cli_progress)
-
-
-def _sample_layer_serial(pio, format, sampler, depth, coordsys, cli_progress):
-    # The usual vertical flip that we may need if tiling into FITS:
-    invert_into_tiles = pio.get_default_vertical_parity_sign() == 1
-
-    with progress_bar(total=tiles_at_depth(depth), show=cli_progress) as progress:
-        for tile in generate_tiles(depth, bottom_only=True, coordsys=coordsys):
-            lon, lat = toast_tile_get_coords(tile)
-            sampled_data = sampler(lon, lat)
-
-            if invert_into_tiles:
-                sampled_data = sampled_data[::-1]
-
-            pio.write_image(tile.pos, Image.from_array(sampled_data), format=format)
-            progress.update(1)
-
-
-def _sample_layer_parallel(
-    pio, format, sampler, depth, coordsys, cli_progress, parallel
-):
-    import multiprocessing as mp
-
-    done_event = mp.Event()
-    queue = mp.Queue(maxsize=2 * parallel)
-    workers = []
-
-    for _ in range(parallel):
-        w = mp.Process(
-            target=_mp_sample_worker, args=(queue, done_event, pio, sampler, format)
-        )
-        w.daemon = True
-        w.start()
-        workers.append(w)
-
-    # Send out tiles:
-
-    with progress_bar(total=tiles_at_depth(depth), show=cli_progress) as progress:
-        for tile in generate_tiles(depth, bottom_only=True, coordsys=coordsys):
-            queue.put(tile)
-            progress.update(1)
-
-    # OK, we're done!
-
-    queue.close()
-    queue.join_thread()
-    done_event.set()
-
-    for w in workers:
-        w.join()
-
-
-def _mp_sample_worker(queue, done_event, pio, sampler, format):
-    """
-    Process tiles on the queue.
-    """
-    from queue import Empty
-
-    # The usual vertical flip that we may need if tiling into FITS:
-    invert_into_tiles = pio.get_default_vertical_parity_sign() == 1
-
-    while True:
-        try:
-            tile = queue.get(True, timeout=1)
-        except Empty:
-            if done_event.is_set():
-                break
-            continue
-
-        lon, lat = toast_tile_get_coords(tile)
-        sampled_data = sampler(lon, lat)
-
-        if invert_into_tiles:
-            sampled_data = sampled_data[::-1]
-
-        pio.write_image(tile.pos, Image.from_array(sampled_data), format=format)
+    p = Pyramid.new_toast(depth, coordsys=coordsys)
+    proc = ToastSampler(pio, sampler, True, format=format)
+    p.visit_leaves(proc.visit_callback, parallel=parallel, cli_progress=cli_progress)
 
 
 def sample_layer_filtered(
@@ -775,129 +695,60 @@ def sample_layer_filtered(
         If true, a progress bar will be printed to the terminal.
     """
 
-    from .par_util import resolve_parallelism
+    from .pyramid import Pyramid
 
-    parallel = resolve_parallelism(parallel)
-
-    if parallel > 1:
-        _sample_filtered_parallel(
-            pio, tile_filter, sampler, depth, coordsys, cli_progress, parallel
-        )
-    else:
-        _sample_filtered_serial(
-            pio, tile_filter, sampler, depth, coordsys, cli_progress
-        )
+    p = Pyramid.new_toast_filtered(depth, tile_filter, coordsys=coordsys)
+    proc = ToastSampler(pio, sampler, False, format=format)
+    p.visit_leaves(proc.visit_callback, parallel=parallel, cli_progress=cli_progress)
 
 
-def _sample_filtered_serial(pio, tile_filter, sampler, depth, coordsys, cli_progress):
-    n_todo = count_tiles_matching_filter(
-        depth, tile_filter, bottom_only=True, coordsys=coordsys
-    )
+class ToastSampler(object):
+    """A utility for performing TOAST sampling on a
+    :class:`~toasty.pyramid.Pyramid`.
 
-    # The usual vertical flip that we may need if tiling into FITS:
-    invert_into_tiles = pio.get_default_vertical_parity_sign() == 1
+    Parameters
+    ----------
+    pio : :class:`toasty.pyramid.PyramidIO`
+        Handle for image I/O on the pyramid
+    sampler : callable
+        The sampler callable that will produce data for tiling.
+    clobber : bool
+        If true, data in any existing tiles will be ignored and destroyed.
+        Otherwise, data from existing tiles will be read and updated. The
+        "clobber" mode is faster but will give incorrect results if other
+        sampling operations will be run on this pyramid.
+    format : optional :class:`str`
+        If provided, override the default data storage format of *pio* with the
+        named format, one of the values in ``toasty.image.SUPPORTED_FORMATS``.
 
-    with progress_bar(total=n_todo, show=cli_progress) as progress:
-        for tile in generate_tiles_filtered(
-            depth, tile_filter, bottom_only=True, coordsys=coordsys
-        ):
-            lon, lat = toast_tile_get_coords(tile)
-            sampled_data = sampler(lon, lat)
+    Notes
+    -----
+    This class provides a :meth:`visit_callback` method that can be passed to
+    the :meth:`toasty.pyramid.Pyramid.visit_leaves` function. This class
+    preserves some state between calls to help speed up processing."""
 
-            if invert_into_tiles:
-                sampled_data = sampled_data[::-1]
+    def __init__(self, pio, sampler, clobber, format=None):
+        self._pio = pio
+        self._sampler = sampler
+        self._clobber = clobber
+        self._format = format
+        self._invert_into_tiles = pio.get_default_vertical_parity_sign() == 1
 
-            img = Image.from_array(sampled_data)
-
-            with pio.update_image(
-                tile.pos, masked_mode=img.mode, default="masked"
-            ) as basis:
-                img.update_into_maskable_buffer(
-                    basis, slice(None), slice(None), slice(None), slice(None)
-                )
-
-            progress.update(1)
-
-    # do not clean lockfiles, for HPC contexts where we're processing different
-    # chunks in parallel.
-
-
-def _sample_filtered_parallel(
-    pio, tile_filter, sampler, depth, coordsys, cli_progress, parallel
-):
-    import multiprocessing as mp
-
-    n_todo = count_tiles_matching_filter(
-        depth, tile_filter, bottom_only=True, coordsys=coordsys
-    )
-
-    done_event = mp.Event()
-    queue = mp.Queue(maxsize=2 * parallel)
-    workers = []
-
-    for _ in range(parallel):
-        w = mp.Process(
-            target=_mp_sample_filtered, args=(queue, done_event, pio, sampler)
-        )
-        w.daemon = True
-        w.start()
-        workers.append(w)
-
-    # Here we go:
-
-    with progress_bar(total=n_todo, show=cli_progress) as progress:
-        for tile in generate_tiles_filtered(
-            depth, tile_filter, bottom_only=True, coordsys=coordsys
-        ):
-            queue.put(tile)
-            progress.update(1)
-
-    # OK, we're done!
-
-    queue.close()
-    queue.join_thread()
-    done_event.set()
-
-    for w in workers:
-        w.join()
-
-    # do not clean lockfiles, for HPC contexts where we're processing different
-    # chunks in parallel.
-
-
-def _mp_sample_filtered(queue, done_event, pio, sampler):
-    """
-    Process tiles on the queue.
-
-    We use ``pio.update_image`` in case we are in an HPC-type context where
-    other chunks may be trying to write out the populate the same tiles as us at
-    the same time.
-    """
-
-    from queue import Empty
-
-    # The usual vertical flip that we may need if tiling into FITS:
-    invert_into_tiles = pio.get_default_vertical_parity_sign() == 1
-
-    while True:
-        try:
-            tile = queue.get(True, timeout=1)
-        except Empty:
-            if done_event.is_set():
-                break
-            continue
-
+    def visit_callback(self, pos, tile):
         lon, lat = toast_tile_get_coords(tile)
-        sampled_data = sampler(lon, lat)
+        sampled_data = self._sampler(lon, lat)
 
-        if invert_into_tiles:
+        if self._invert_into_tiles:
             sampled_data = sampled_data[::-1]
 
         img = Image.from_array(sampled_data)
 
-        with pio.update_image(
-            tile.pos, masked_mode=img.mode, default="masked"
-        ) as basis:
-            img.update_into_maskable_buffer(
-                basis, slice(None), slice(None), slice(None), slice(None)
-            )
+        if self._clobber:
+            self._pio.write_image(pos, img, format=self._format)
+        else:
+            with self._pio.update_image(
+                pos, masked_mode=img.mode, default="masked"
+            ) as basis:
+                img.update_into_maskable_buffer(
+                    basis, slice(None), slice(None), slice(None), slice(None)
+                )


### PR DESCRIPTION
Another opportunity to clean up a bunch of code using the new Pyramid infrastructure. This has gotten a lot of testing at scale in the DECaPS2 dataset.