### PR TITLE
Fits thumbnails

### DIFF
--- a/docs/api/toasty.image.ImageMode.rst
+++ b/docs/api/toasty.image.ImageMode.rst
@@ -23,7 +23,6 @@ ImageMode
 
       ~ImageMode.from_array_info
       ~ImageMode.make_maskable_buffer
-      ~ImageMode.try_as_pil
 
    .. rubric:: Attributes Documentation
 
@@ -38,4 +37,3 @@ ImageMode
 
    .. automethod:: from_array_info
    .. automethod:: make_maskable_buffer
-   .. automethod:: try_as_pil

--- a/toasty/builder.py
+++ b/toasty/builder.py
@@ -257,7 +257,9 @@ class Builder(object):
         return self
 
     def make_thumbnail_from_other(self, thumbnail_image):
-        thumb = thumbnail_image.make_thumbnail_bitmap()
+        thumb = thumbnail_image.make_thumbnail_bitmap(
+            self.imgset.pixel_cut_low, self.imgset.pixel_cut_high
+        )
         with self.pio.open_metadata_for_write("thumb.jpg") as f:
             thumb.save(f, format="JPEG")
         self.imgset.thumbnail_url = "thumb.jpg"

--- a/toasty/fits_tiler.py
+++ b/toasty/fits_tiler.py
@@ -167,6 +167,9 @@ class FitsTiler(object):
         else:
             self._tile_tan(cli_progress, parallel, **kwargs)
 
+        for img in self.coll.images():
+            self.builder.make_thumbnail_from_other(img)
+            break
         self.builder.write_index_rel_wtml(
             add_place_for_toast=self.add_place_for_toast,
         )

--- a/toasty/image.py
+++ b/toasty/image.py
@@ -850,14 +850,14 @@ class Image(object):
         pixel_cut_low : number or ``None`` (the default)
             An optional value used to stretch the pixel values to the new range
             as defined by pixel_cut_low and pixel_cut_high. Only used if the
-            image was not loaded as a PIL image, and mus be used together with
-            pixel_cut_high. To get resonable values for arrays with dtype other
+            image was not loaded as a PIL image, and must be used together with
+            pixel_cut_high. To get reasonable values for arrays with dtype other
             than ``unit8`` this parameter is highly recommended.
         pixel_cut_high : number or ``None`` (the default)
             An optional value used to stretch the pixel values to the new range
             as defined by pixel_cut_low and pixel_cut_high. Only used if the
-            image was not loaded as a PIL image, and mus be used together with
-            pixel_cut_low. To get resonable values for arrays with dtype other
+            image was not loaded as a PIL image, and must be used together with
+            pixel_cut_low. To get reasonable values for arrays with dtype other
             than ``unit8`` this parameter is highly recommended.
         Returns
         -------
@@ -1253,14 +1253,14 @@ class Image(object):
         pixel_cut_low : number or ``None`` (the default)
             An optional value used to stretch the pixel values to the new range
             as defined by pixel_cut_low and pixel_cut_high. Only used if the
-            image was not loaded as a PIL image, and mus be used together with
-            pixel_cut_high. To get resonable values for arrays with dtype other
+            image was not loaded as a PIL image, and must be used together with
+            pixel_cut_high. To get reasonable values for arrays with dtype other
             than ``unit8`` this parameter is highly recommended.
         pixel_cut_high : number or ``None`` (the default)
             An optional value used to stretch the pixel values to the new range
             as defined by pixel_cut_low and pixel_cut_high. Only used if the
-            image was not loaded as a PIL image, and mus be used together with
-            pixel_cut_low. To get resonable values for arrays with dtype other
+            image was not loaded as a PIL image, and must be used together with
+            pixel_cut_low. To get reasonable values for arrays with dtype other
             than ``unit8`` this parameter is highly recommended.
 
         Returns


### PR DESCRIPTION
Enabled creation of thumbnails from non PIL formats. 

For FITS files we are using linear stretch and the pixel cut values calculated from the tiling process.

1. I don't see a use case for `try_as_pil`, but maybe I just have trouble imagining when it would be useful. 
2. It seems like there should be an easy way to do this in numpy `array = (self._array - pixel_cut_low) / (
                pixel_cut_high - pixel_cut_low
            ) * 255 + 0.5`  without changing the alpha channel, if there is one. Do you happen to know what I'm looking for, I seem to be googling the wrong thing.  Otherwise, I'll look into this again later.