### PR TITLE
Update the "front door" email address to hello@worldwidetelescope.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,15 @@
 <!--pypi-begin-->
 [toasty] is a Python library that helps you create “tile pyramids” from
 astronomical image data as used in the [TOAST] format. These multi-resolution
-maps can be viewed in software such as the [AAS] [WorldWide Telescope].
+maps can be viewed in software such as [WorldWide Telescope].
 
 [toasty]: https://toasty.readthedocs.io/
 [TOAST]: https://doi.org/10.3847/1538-4365/aaf79e
-[AAS]: https://aas.org/
 [WorldWide Telescope]: http://www.worldwidetelescope.org/
 
 [toasty] was originally written by [Chris Beaumont], benefited from
 contributions by Clara Brasseur (Space Telescope Science Institute), and is
-currently maintained as part of the AAS [WorldWide Telescope] project.
+currently maintained as part of the [WorldWide Telescope] project.
 
 [Chris Beaumont]: https://chrisbeaumont.org/
 <!--pypi-end-->
@@ -100,13 +99,13 @@ and [PyPI](https://pypi.org/project/toasty/#history).
 
 ## Legalities
 
-[toasty] is copyright Chris Beaumont, Clara Brasseur, and the AAS WorldWide
+[toasty] is copyright Chris Beaumont, Clara Brasseur, and the WorldWide
 Telescope Team. It is licensed under the [MIT License](./LICENSE).
 
 
 ## Acknowledgments
 
-[toasty] is part of the AAS WorldWide Telescope system, a [.NET Foundation]
+[toasty] is part of the WorldWide Telescope system, a [.NET Foundation]
 project managed by the non-profit [American Astronomical Society] (AAS). Work
 on WWT has been supported by the AAS, the US [National Science Foundation]
 (grants [1550701], [1642446], and [2004840]), the [Gordon and Betty Moore Foundation], and

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # -*- mode: python; coding: utf-8 -*-
-# Copyright 2013-2022 Chris Beaumont and the AAS WorldWide Telescope team
+# Copyright 2013-2023 Chris Beaumont and the WorldWide Telescope team
 # Licensed under the MIT License
 
 from Cython.Distutils import build_ext  # in pyproject.toml
@@ -37,14 +37,14 @@ project homepage].
 setup_args = dict(
     name="toasty",  # cranko project-name
     version="0.dev0",  # cranko project-version
-    description="Generate TOAST image tile pyramids from existing image data",
+    description="Generate image tile pyramids from existing image data",
     long_description=get_long_desc(),
     long_description_content_type="text/markdown",
     url="https://toasty.readthedocs.io/",
     license="MIT",
     platforms="Linux, Mac OS X",
-    author="Chris Beaumont, AAS WorldWide Telescope Team",
-    author_email="wwt@aas.org",
+    author="Chris Beaumont, WorldWide Telescope Team",
+    author_email="hello@worldwidetelescope.org",
     classifiers=[
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This is yet another part of the sponsorship migration.

Related pull requests cross-linked at: https://github.com/WorldWideTelescope/worldwidetelescope.github.io/pull/88

Also update some other bits that need changing for the migration.